### PR TITLE
Copy twitter-specific CI config vars from dense to sparse repo on clone

### DIFF
--- a/focus/testing/src/scratch_git_repo.rs
+++ b/focus/testing/src/scratch_git_repo.rs
@@ -175,6 +175,29 @@ impl ScratchGitRepo {
             .assert()
             .success();
 
+        git_binary
+            .command()
+            .arg("config")
+            .arg("--add")
+            .arg("--local")
+            .arg("ci.alt.remote")
+            .arg("https://git.twitter.biz/source-ci")
+            .current_dir(&repo_path)
+            .assert()
+            .success();
+
+        git_binary
+            .command()
+            .arg("config")
+            .arg("--add")
+            .arg("--local")
+            .arg("--bool")
+            .arg("ci.alt.enabled")
+            .arg("true")
+            .current_dir(&repo_path)
+            .assert()
+            .success();
+
         let mut test_file = repo_path.clone();
         test_file.push("d_0_0");
         std::fs::create_dir(test_file.as_path()).unwrap();


### PR DESCRIPTION
The twitter `arc` command expects that there will be two CI related git-config vars set. This change will copy the value of those vars from the dense repo to the sparse repo as part of the clone operation.