### PR TITLE
Project Cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +301,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "bzip2-sys"
@@ -508,6 +527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -843,6 +881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,10 +1029,12 @@ dependencies = [
  "chrono",
  "content-addressed-cache",
  "criterion",
+ "crossbeam",
  "dirs",
  "focus-testing",
  "focus-util",
  "git2",
+ "hex 0.4.3",
  "insta",
  "lazy_static",
  "maplit",
@@ -984,6 +1043,8 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
+ "reqwest",
+ "rocksdb",
  "serde",
  "serde-xml-rs",
  "serde_derive",
@@ -1175,6 +1236,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1265,15 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -1236,8 +1321,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1312,6 +1399,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,12 +1464,86 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.3",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.3",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1428,6 +1608,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1655,6 +1841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1859,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1832,6 +2054,32 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -2319,6 +2567,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,10 +2673,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2474,6 +2794,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.3",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2943,6 +3275,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+dependencies = [
+ "autocfg 1.1.0",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,6 +3341,12 @@ dependencies = [
  "uuid",
  "whoami",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -3075,6 +3455,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuikit"
@@ -3255,6 +3641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3685,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3469,6 +3877,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winrt-notification"

--- a/content-addressed-cache/Cargo.toml
+++ b/content-addressed-cache/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.56"
-git2 = "0.14.2"
+git2 = { version = "0.14.2", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 focus-util = { path = "../focus/util" }
 hex = "0.3.1"
 lazy_static = "1.4.0"

--- a/focus/doc/project_cache.md
+++ b/focus/doc/project_cache.md
@@ -1,0 +1,45 @@
+# Project Cache 
+
+The project cache is a caches pattern sets for projects defined in a repository. It can be used in repositories where the selection includes only predefined projects to skip slower synchronization mechansisms. 
+
+It is keyed on a _build graph hash_, a digest of all of the build-relevant files in the tree. The cache also contains records mapping commit IDs to build graph hashes to reduce the need to perform that computation unless the build graph has been locally modified. Calculating this hash with Twitter's ~24GiB object database takes about approximately 9 seconds on a MacBook Pro (16-inch, 2019) with the 2.4 GHz 8-Core Intel Core i9 processor. N.B.: we aren't taking full advantage of these precomputed commit to build graph hashes since we don't have a mechanism for fetching them yet. 
+
+## Using Project Cache
+On the workstation, the selection can only contain projects. You should set up a CI job with multiple shards as described in [generating and pushing](#generating-and-pushing) and configure clients with the appropriate endpoint -- see [configuration](#configuration).
+
+## Conceptual Schema
+```
+  [Commit ID] -> [Build Graph Hash (SHA-256)] -+-> [Project A]
+                                               |       \
+                                               |        `-> [Pattern Set]
+                                               |
+                                               +-> [Project B]
+                                               |     | 
+                                               .     `-> [Pattern Set]
+                                               .
+                                               . 
+```
+
+## Configuration
+The cache endpoint is specified in the  Git configuration as the `focus.project-cache-endpoint` variable. If configured, Focus will attempt to fetch from this endpoint cache content for the commit it is trying to sync if it is not already present in the local project cache database.
+
+## Content Storage
+Content is stored on an HTTP server using a simple scheme. It uses `PUT` and `GET` to store and fetch data. Only repos generating content need to be able to perform `PUT` requests against the endpoint. 
+
+## Generating and pushing 
+The `focus project-cache` command allows you to interact with the cache. The `focus project-cache push` command will generate cache content and push it to the given endpoint. Index generation is sharded and the different shards can be calculated by separate machines every time a commit lands at the head of your repository. 
+
+You could set up a CI job with two different shards like so:
+
+> On CI machine #1:
+> `focus project-cache push --shard-count=2 --shard-index=0`
+> 
+> On CI machine #2:
+> `focus project-cache push --shard-count=2 --shard-index=1`
+
+
+Any number of shards can be used.
+
+The endpoint path must refer to an existing directory on the server. Files are written there forming a flat namespace. Each repository should have a different endpoint path.
+
+Care should be taken to expire content so that your server's disk does not fill up. Delete files whose creation time preceeds the time window your sparse repos HEAD commits map to: running a simple command such as `find $endpoint_path -ctime +7 -delete` should work well for cleaning up the path on a plain HTTP server storing and serving files from disk; in this case deleting all files older than one week. You might want to delete the manifest files ending in the pattern `.manifest_v*.json` first to prevent errors from Focus repos that are fetching.

--- a/focus/internals/Cargo.toml
+++ b/focus/internals/Cargo.toml
@@ -11,7 +11,7 @@ content-addressed-cache = { path = "../../content-addressed-cache" }
 crossbeam = "0.8.2"
 dirs = "4.0.0"
 focus-util = { path = "../util" }
-git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "52716b2148888cf9a3b605eed9414544c12a778f", features = [
+git2 = { version = "0.14.2", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/internals/Cargo.toml
+++ b/focus/internals/Cargo.toml
@@ -8,15 +8,22 @@ edition = "2021"
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 chrono = { version = "0.4", features = ["serde"] }
 content-addressed-cache = { path = "../../content-addressed-cache" }
+crossbeam = "0.8.2"
 dirs = "4.0.0"
 focus-util = { path = "../util" }
-git2 = "0.14.2"
+git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "52716b2148888cf9a3b605eed9414544c12a778f", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 lazy_static = "1.4.0"
 nix = "0.23.0"
 once_cell = "1.4.0"
 rand = "0.8.4"
 rayon = "1.5.1"
 regex = "1.5.5"
+reqwest = { version = "0.11.11", features = [ "blocking", "gzip" ] }
+rocksdb = "0.19.0"
+hex = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde-xml-rs = "0.5.1"
 serde_derive = "1.0.130"

--- a/focus/internals/src/lib/lib.rs
+++ b/focus/internals/src/lib/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::too_many_arguments)]
 // Copyright 2022 Twitter, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +5,8 @@ pub mod hashing;
 pub mod index;
 pub mod locking;
 pub mod model;
+pub mod project_cache;
+pub mod storage;
 pub mod target;
 pub mod target_resolver;
 pub mod tracker;

--- a/focus/internals/src/lib/model/mod.rs
+++ b/focus/internals/src/lib/model/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod configuration;
+pub mod data_paths;
 pub mod outlining;
 mod persistence;
 pub mod repo;

--- a/focus/internals/src/lib/model/selection/mod.rs
+++ b/focus/internals/src/lib/model/selection/mod.rs
@@ -11,8 +11,7 @@ mod selection;
 pub use selection::Selection;
 pub(crate) use selection::SelectionManager;
 
-mod data_paths;
-use data_paths::DataPaths;
+use super::data_paths::DataPaths;
 
 mod operations;
 pub use operations::Operation;

--- a/focus/internals/src/lib/model/selection/project.rs
+++ b/focus/internals/src/lib/model/selection/project.rs
@@ -122,7 +122,7 @@ struct ProjectSet {
     pub projects: HashSet<Project>,
 }
 
-/// ProjectSetManager loads project sets from files defined in the repository.
+/// ProjectSetStore loads project sets from files defined in the repository.
 struct ProjectSetStore(FileBackedCollection<ProjectSet>);
 
 impl ProjectSetStore {

--- a/focus/internals/src/lib/model/selection/selection.rs
+++ b/focus/internals/src/lib/model/selection/selection.rs
@@ -253,6 +253,14 @@ impl SelectionManager {
     pub fn computed_selection(&self) -> Result<Selection> {
         let mut selection = self.selection.clone();
         debug!(selected = ?selection, "User-selected projects");
+        let mandatory_projects = self.mandatory_projects();
+        debug!(mandatory = ?mandatory_projects, "Mandatory projects");
+        selection.projects.extend(mandatory_projects);
+        Ok(selection)
+    }
+
+    /// Returns mandatory projects.
+    pub fn mandatory_projects(&self) -> Vec<Project> {
         let mandatory_projects = self
             .project_catalog
             .mandatory_projects
@@ -260,9 +268,7 @@ impl SelectionManager {
             .values()
             .cloned()
             .collect::<Vec<Project>>();
-        debug!(mandatory = ?mandatory_projects, "Mandatory projects");
-        selection.projects.extend(mandatory_projects);
-        Ok(selection)
+        mandatory_projects
     }
 
     pub fn compute_complete_target_set(&self) -> Result<HashSet<Target>> {

--- a/focus/internals/src/lib/project_cache/http_cache_backend.rs
+++ b/focus/internals/src/lib/project_cache/http_cache_backend.rs
@@ -1,0 +1,70 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use url::Url;
+
+use super::*;
+
+/// A cache backend that uses HTTP GET to retrieve models and HTTP PUT to store them.
+pub struct HttpCacheBackend {
+    endpoint: Url,
+}
+
+impl HttpCacheBackend {
+    pub fn new(endpoint: Url) -> Self {
+        Self { endpoint }
+    }
+
+    fn blocking_client(&self) -> Result<Client> {
+        // TODO: use vergen to get the SHA, cargo features, ...
+        static APP_USER_AGENT: &str = concat!("focus", "/", env!("CARGO_PKG_VERSION"));
+        Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(APP_USER_AGENT)
+            .build()
+            .map_err(anyhow::Error::new)
+    }
+}
+
+impl ProjectCacheBackend for HttpCacheBackend {
+    fn endpoint(&self) -> Url {
+        self.endpoint.clone()
+    }
+
+    // Fetch a model from the given URL and decode it from its JSON representation.
+    fn load_model(&self, url: Url) -> Result<Vec<u8>> {
+        let span = tracing::info_span!("Fetching");
+        let _guard = span.enter();
+        tracing::debug!(url = ?url.as_str(), "GET");
+        let response = self
+            .blocking_client()?
+            .get(url)
+            .send()
+            .context("GET failed")?
+            .error_for_status()?;
+        tracing::debug!(status = ?response.status(), "OK");
+        Ok(response
+            .bytes()
+            .context("Reading response failed")?
+            .to_vec())
+    }
+
+    // Encode the given model as JSON and upload it using HTTP PUT to the given URL.
+    fn store(&self, url: Url, value: Vec<u8>) -> Result<()> {
+        // TODO: Add an ETag to skip upload if the content is identical.
+        let span = tracing::info_span!("Putting");
+        let _guard = span.enter();
+        tracing::debug!(url = ?url.as_str(), "PUT");
+        let response = self
+            .blocking_client()?
+            .put(url)
+            .body(value)
+            .send()
+            .context("PUT failed")?
+            .error_for_status()?;
+        tracing::debug!(status = ?response.status(), "OK");
+        Ok(())
+    }
+}

--- a/focus/internals/src/lib/project_cache/local_cache_backend.rs
+++ b/focus/internals/src/lib/project_cache/local_cache_backend.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Borrow;
+
+use anyhow::{Context, Result};
+use url::Url;
+
+use super::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DatabaseCacheBackendError {
+    #[error("Local cache backend requires a 'file' scheme in the endpoint URL")]
+    InappropriateScheme,
+}
+
+/// A cache backend that stores and retrieves content to and from a database.
+pub struct LocalCacheBackend {
+    pub endpoint: Url,
+    pub database: rocksdb::DB,
+}
+
+impl LocalCacheBackend {
+    pub fn new(endpoint: Url) -> Result<Self> {
+        if !endpoint.scheme().eq_ignore_ascii_case("file") {
+            return Err(anyhow::Error::new(
+                DatabaseCacheBackendError::InappropriateScheme,
+            ));
+        }
+
+        let path = endpoint
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Endpoint is missing path"))
+            .context("Converting the endpoint to a local path failed")?;
+        let database = storage::open_database(&path, Duration::from_secs(84600))
+            .context("Opening local project cache database")?;
+
+        Ok(Self { endpoint, database })
+    }
+}
+
+impl ProjectCacheBackend for LocalCacheBackend {
+    fn load_model(&self, url: Url) -> Result<Vec<u8>> {
+        let key = url.path();
+        if let Ok(Some(repr)) = self.database.borrow().get(&key) {
+            debug!(?key, "GET: Found");
+            Ok(repr)
+        } else {
+            warn!(?key, "GET: Missing");
+            Err(anyhow::anyhow!("Missing"))
+        }
+    }
+
+    fn store(&self, url: Url, value: Vec<u8>) -> Result<()> {
+        let key = url.path();
+        debug!(?key, "PUT");
+        self.database
+            .put(&key, value)
+            .with_context(|| format!("Writing key '{}' failed", &key))
+    }
+
+    fn endpoint(&self) -> Url {
+        self.endpoint.clone()
+    }
+}

--- a/focus/internals/src/lib/project_cache/mod.rs
+++ b/focus/internals/src/lib/project_cache/mod.rs
@@ -1,0 +1,430 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod http_cache_backend;
+mod local_cache_backend;
+
+mod remote;
+pub use http_cache_backend::HttpCacheBackend;
+pub use local_cache_backend::LocalCacheBackend;
+pub use remote::ProjectCacheBackend;
+mod model;
+pub(crate) use model::{Export, ExportManifest, Key, RepoIdentifier, Value};
+
+use tracing::{debug, info, info_span, warn};
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    convert::{TryFrom, TryInto},
+    ffi::OsStr,
+    iter::FromIterator,
+    os::unix::prelude::OsStrExt,
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
+
+use crate::model::{data_paths::DataPaths, outlining::PatternSet, repo::Repo, selection::Target};
+use anyhow::{bail, Context};
+use focus_util::{app::App, paths::is_relevant_to_build_graph};
+use git2::{ObjectType, Oid, TreeWalkMode, TreeWalkResult};
+use lazy_static::lazy_static;
+use rocksdb::WriteBatch;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::storage;
+
+use self::{
+    model::NamespacedKey,
+    remote::{fetch_exports, store_export},
+};
+
+const PROJECT_CACHE_VERSION: usize = 1;
+
+lazy_static! {
+    static ref VERSION_KEY_SUFFIX: String = format!(";V{}", PROJECT_CACHE_VERSION);
+    static ref VERSION_KEY_PATH_COMPONENT: String = format!("v{}", PROJECT_CACHE_VERSION);
+    static ref IMPORT_RECEIPT_IOTA_SERIALIZED: Vec<u8> =
+        serde_json::to_vec(&Value::ImportReceiptIota).unwrap();
+}
+const PROJECT_CACHE_TTL: Duration = Duration::new(86400 * 14, 0);
+
+/// ProjectCache caches pattern sets for projects. This is a coarse-grained cache intended to
+/// be used when there are no ad-hoc targets present in the selection. It is a bit of a kludge
+/// and meant to be support fast synchronization until we can work through all of the correctness
+/// and performance issues with the more accurate and fine-grained precomputed index.
+pub struct ProjectCache<'cache> {
+    app: Arc<App>,
+    repo: &'cache Repo,
+    identifier: RepoIdentifier,
+    database: rocksdb::DB,
+    backend: Box<dyn ProjectCacheBackend>,
+}
+
+impl<'cache> ProjectCache<'cache> {
+    /// Create a new project cache instance for the provided Repo.
+    pub fn new(repo: &'cache Repo, endpoint: Url, app: Arc<App>) -> anyhow::Result<Self> {
+        let identifier = RepoIdentifier::from(repo.underlying())?;
+        let working_tree = repo
+            .working_tree()
+            .ok_or_else(|| anyhow::anyhow!("Missing working tree"))?;
+        let data_paths = DataPaths::from_working_tree(working_tree)?;
+        let database = {
+            let span = info_span!("Opening project cache");
+            let _guard = span.enter();
+            let database_path = data_paths.project_cache_dir.as_path();
+            let result = storage::open_database(database_path, PROJECT_CACHE_TTL)
+                .context("Opening project cache database")?;
+            debug!(?database_path, "Database is open");
+            result
+        };
+        let backend = Self::make_backend(&endpoint)?;
+        Ok(Self {
+            app,
+            repo,
+            identifier,
+            database,
+            backend,
+        })
+    }
+
+    /// Read a value from the cache, possibly faulting it using the optional callback.
+    #[allow(clippy::type_complexity)] // Can't do anything about `fault_cb` because of the ref.
+    pub(crate) fn read_or_fault(
+        &self,
+        key: &Key,
+        fault_cb: Option<&dyn Fn(&Key, &Repo) -> anyhow::Result<Option<Value>>>,
+    ) -> anyhow::Result<(NamespacedKey, Option<Value>)> {
+        let outer_key = NamespacedKey {
+            repository: self.identifier.clone(),
+            underlying: key.to_owned(),
+            version: PROJECT_CACHE_VERSION,
+        };
+        let key_str: String = outer_key.clone().try_into()?;
+
+        if let Some(value_slice) = self
+            .database
+            .get_pinned(key_str.as_bytes())
+            .with_context(|| format!("Reading value '{}' failed", &key_str))?
+        {
+            // A value was found, deserialize it and return it.
+            let value: Value =
+                serde_json::from_slice(&value_slice).context("Parsing value failed")?;
+            return Ok((outer_key, Some(value)));
+        }
+
+        if fault_cb.is_none() {
+            warn!(key = ?key_str, "Not found; cannot be faulted");
+            bail!("Object not found and cannot be faulted")
+        }
+
+        // Fault the value from the given callback and store it
+        let span = info_span!("Faulting");
+        info!(key = ?key_str, "Not found; faulting");
+        let _guard = span.enter();
+        if let Some(value) = fault_cb.unwrap()(key, self.repo)
+            .with_context(|| format!("Faulting object for key '{}'", key))?
+        {
+            debug!(?value, "Faulted object");
+            let serialized_value = serde_json::to_vec(&value).with_context(|| {
+                format!(
+                    "Serializing  value {:?} for key '{}' failed",
+                    &value, &key_str
+                )
+            })?;
+            self.database
+                .put(key_str.as_bytes(), serialized_value)
+                .with_context(|| format!("Writing value '{}' failed", key_str))?;
+            Ok((outer_key, Some(value)))
+        } else {
+            // Fault function returned none
+            warn!("Fault returned nothing");
+            Ok((outer_key, None))
+        }
+    }
+
+    /// Get or calculate the build graph hash at a given commit.
+    pub fn build_graph_hash(
+        &self,
+        commit_id: Oid,
+        allow_fault: bool,
+    ) -> anyhow::Result<(NamespacedKey, Option<Value>)> {
+        let key = Key::CommitToBuildGraphHash {
+            commit_id: commit_id.as_bytes().to_vec(),
+        };
+
+        let calculate = move |key: &Key, repo: &Repo| -> anyhow::Result<Option<Value>> {
+            match key {
+                Key::CommitToBuildGraphHash { commit_id } => {
+                    let git_repo = repo.underlying();
+                    let commit_id =
+                        Oid::from_bytes(commit_id).context("Marshalling commit ID failed")?;
+                    let commit = git_repo
+                        .find_commit(commit_id)
+                        .context("Resolving commit failed")?;
+                    let tree = commit.tree().context("Resolving tree failed")?;
+
+                    let mut digest = Sha256::new();
+                    tree.walk(TreeWalkMode::PreOrder, |directory, entry| {
+                        if entry
+                            .kind()
+                            .map(|kind| kind == ObjectType::Blob)
+                            .unwrap_or(false)
+                        {
+                            let filename = Path::new(OsStr::from_bytes(entry.name_bytes()));
+                            if is_relevant_to_build_graph(filename) {
+                                digest.update(directory.as_bytes());
+                                digest.update(entry.name_bytes());
+                                digest.update(entry.id().as_bytes());
+                            }
+                        }
+
+                        TreeWalkResult::Ok
+                    })
+                    .context("Walking tree failed")?;
+
+                    Ok(Some(Value::BuildGraphHash {
+                        build_graph_hash: digest.finalize().to_vec(),
+                    }))
+                }
+                _ => Err(anyhow::anyhow!("Unexpected key type {:?}", &key)),
+            }
+        };
+
+        self.read_or_fault(&key, if allow_fault { Some(&calculate) } else { None })
+    }
+
+    /// Outling the given targets at a specific commit.
+    fn outline(&self, commit_id: Oid, targets: &HashSet<Target>) -> anyhow::Result<PatternSet> {
+        let outlining_tree = self
+            .repo
+            .outlining_tree()
+            .ok_or_else(|| anyhow::anyhow!("Missing outlining tree"))?;
+        let (patterns, _resolution_result) = outlining_tree
+            .outline(commit_id, targets, self.app.clone())
+            .with_context(|| {
+                format!(
+                    "Outlining targets ({:?}) at commit {} failed",
+                    &targets, commit_id
+                )
+            })?;
+        Ok(patterns)
+    }
+
+    pub fn get_build_graph_hash(
+        &self,
+        commit_id: Oid,
+        allow_fault: bool,
+    ) -> anyhow::Result<(NamespacedKey, Vec<u8>)> {
+        let (build_graph_hash_key, build_graph_hash) = self
+            .build_graph_hash(commit_id, allow_fault)
+            .context("Determining build graph hash")?;
+        if let Some(Value::BuildGraphHash {
+            build_graph_hash: value,
+        }) = build_graph_hash
+        {
+            Ok((build_graph_hash_key, value))
+        } else {
+            Err(anyhow::anyhow!("Unexpected build graph hash value type"))
+        }
+    }
+
+    /// Generate all projects in the given shard.
+    pub fn generate_all(
+        &self,
+        commit_id: Oid,
+        shard_index: usize,
+        shard_count: usize,
+    ) -> anyhow::Result<Vec<NamespacedKey>> {
+        let selection_manager = self.repo.selection_manager()?;
+        let catalog = selection_manager.project_catalog();
+        let project_names = catalog
+            .optional_projects
+            .underlying
+            .iter()
+            .map(|(name, _project)| name.clone())
+            .collect::<BTreeSet<String>>();
+        let project_names = Vec::from_iter(project_names.into_iter());
+        let (build_graph_hash_key, build_graph_hash) =
+            self.get_build_graph_hash(commit_id, true)?;
+        let mut keys = vec![build_graph_hash_key];
+        let shard_size = project_names.len() / shard_count;
+        let mut shards = project_names.chunks(shard_size).skip(shard_index);
+        let build_graph_hash_str = hex::encode(&build_graph_hash);
+        let commit_id_str = hex::encode(commit_id.as_bytes());
+        let project_names = shards
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No such shard"))?;
+        info!(
+            ?shard_index,
+            ?shard_count,
+            ?project_names,
+            commit_id = ?commit_id_str,
+            build_graph_hash = ?build_graph_hash_str,
+            "Generating project pattern cache"
+        );
+        for project_name in project_names {
+            let (key, value) = self
+                .get_project(commit_id, &build_graph_hash, project_name, true)
+                .with_context(|| {
+                    format!("Generating cache content for project {}", project_name)
+                })?;
+            let _value = value.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not generate patterns to cache for project '{}'",
+                    project_name
+                )
+            })?;
+            keys.push(key);
+        }
+
+        Ok(keys)
+    }
+
+    /// Get (possibly fault) a project from the cache.
+    pub fn get_project(
+        &self,
+        commit_id: Oid,
+        build_graph_hash: &[u8],
+        project_name: &str,
+        fault: bool,
+    ) -> anyhow::Result<(NamespacedKey, Option<Value>)> {
+        let calculate = move |key: &Key, repo: &Repo| -> anyhow::Result<Option<Value>> {
+            if let Key::OptionalProjectPatternSet { project_name, .. } = key {
+                let selection_manager = repo.selection_manager()?;
+                let catalog = selection_manager.project_catalog();
+                let span = info_span!("Resolving");
+                let _guard = span.enter();
+
+                let project = catalog
+                    .optional_projects
+                    .underlying
+                    .get(project_name)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(format!("No such project '{}'", &project_name))
+                    })?;
+                let targets = {
+                    let mut targets = HashSet::<Target>::new();
+                    for repr in &project.targets {
+                        let target = Target::try_from(repr.as_str())?;
+                        targets.insert(target);
+                    }
+                    targets
+                };
+                info!(project = ?project_name, "Outlining");
+                if let Ok(patterns) = self.outline(commit_id, &targets) {
+                    Ok(Some(Value::OptionalProjectPatternSet(patterns)))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Err(anyhow::anyhow!("Unsupported key type"))
+            }
+        };
+
+        let key = Key::OptionalProjectPatternSet {
+            build_graph_hash: build_graph_hash.to_vec(),
+            project_name: project_name.to_owned(),
+        };
+        self.read_or_fault(&key, if fault { Some(&calculate) } else { None })
+    }
+
+    /// Generate and push sharded project cache data.
+    pub fn generate_and_push(
+        &self,
+        keys: &Vec<NamespacedKey>,
+        build_graph_hash: &Vec<u8>,
+        shard_index: usize,
+        shard_count: usize,
+    ) -> anyhow::Result<()> {
+        let mut items = Vec::<(NamespacedKey, Value)>::new();
+        for key in keys {
+            let (key, value) = self
+                .read_or_fault(&key.underlying, None)
+                .with_context(|| format!("Reading key {:?} failed", key))?;
+            let value = value.ok_or_else(|| anyhow::anyhow!("Key {:?} not found", key))?;
+            items.push((key, value));
+        }
+
+        let export = Export {
+            shard_index,
+            shard_count,
+            items,
+        };
+
+        let manifest = ExportManifest { shard_count };
+
+        store_export(self.backend.as_ref(), build_graph_hash, &manifest, &export)
+            .context("Failed to upload the project cache export")
+    }
+
+    pub fn fetch(&self, build_graph_hash: &Vec<u8>) -> anyhow::Result<()> {
+        // TODO: Expensive in terms of memory consumed. Figure out a better transaction / streaming strategy later.
+        // TODO: We decode something to just encode it, which is wasteful. Fix that.
+        let exports =
+            fetch_exports(self.backend.as_ref(), build_graph_hash).with_context(|| {
+                anyhow::anyhow!(
+                    "Fetching project cache data for build graph @ {} failed",
+                    hex::encode(build_graph_hash)
+                )
+            })?;
+
+        let mut batch = WriteBatch::default();
+        // Write exports into the batch
+        for export in exports.into_iter() {
+            for (key, value) in export.items {
+                let key_str: String = key.try_into()?;
+                let serialized_value = serde_json::to_vec(&value).with_context(|| {
+                    format!(
+                        "Serializing  value {:?} for key '{}' failed",
+                        &value, &key_str
+                    )
+                })?;
+                batch.put(key_str.as_bytes(), serialized_value);
+            }
+        }
+        // Add receipt
+        let receipt_key: String = {
+            let key = self.import_receipt_key(build_graph_hash);
+            key.try_into()?
+        };
+        self.database
+            .put(receipt_key, IMPORT_RECEIPT_IOTA_SERIALIZED.as_slice())
+            .map_err(anyhow::Error::new)?;
+
+        // Write the batch
+        self.database.write(batch).with_context(|| {
+            format!(
+                "Writing data for build graph state '{}' failed",
+                &hex::encode(build_graph_hash)
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn import_receipt_key(&self, build_graph_hash: &Vec<u8>) -> NamespacedKey {
+        NamespacedKey {
+            repository: self.identifier.clone(),
+            underlying: Key::ImportReceipt {
+                build_graph_hash: build_graph_hash.to_owned(),
+            },
+            version: PROJECT_CACHE_VERSION,
+        }
+    }
+
+    /// Determine if the given build graph hash is marked as having been imported
+    pub fn is_imported(&self, build_graph_hash: &Vec<u8>) -> anyhow::Result<bool> {
+        let key_str: String = self.import_receipt_key(build_graph_hash).try_into()?;
+        Ok(self.database.get_pinned(&key_str)?.is_some())
+    }
+
+    pub fn make_backend(endpoint: &Url) -> anyhow::Result<Box<dyn ProjectCacheBackend>> {
+        if endpoint.scheme().eq_ignore_ascii_case("file") {
+            Ok(Box::new(LocalCacheBackend::new(endpoint.clone())?))
+        } else {
+            Ok(Box::new(HttpCacheBackend::new(endpoint.clone())))
+        }
+    }
+}

--- a/focus/internals/src/lib/project_cache/model.rs
+++ b/focus/internals/src/lib/project_cache/model.rs
@@ -1,0 +1,205 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context;
+
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use url::Url;
+
+use crate::model::outlining::PatternSet;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RepoIdentifier {
+    pub(crate) host: String,
+    pub(crate) name: String,
+}
+
+impl RepoIdentifier {
+    pub fn from(repository: &git2::Repository) -> anyhow::Result<RepoIdentifier> {
+        // TODO: Fix this to not only work with the 'origin' remote.
+        let remote = repository
+            .find_remote("origin")
+            .context("Resolving origin remote")?;
+        let url = remote
+            .url()
+            .ok_or_else(|| anyhow::anyhow!("Origin remote has no URL"))?;
+        let url = Url::parse(url)
+            .with_context(|| format!("Could not parse origin URL from '{}'", url))?;
+        RepoIdentifier::try_from(url)
+    }
+}
+
+impl TryFrom<Url> for RepoIdentifier {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        let host = value
+            .host_str()
+            .unwrap_or_else(|| {
+                if value.scheme().eq("file") {
+                    "localhost"
+                } else {
+                    "unknown"
+                }
+            })
+            .to_owned();
+        let host = host;
+        let name = value.path();
+        let name = name.strip_prefix('/').unwrap_or(name); // Strip leading '/'
+        let name = name.strip_suffix(".git").unwrap_or(name).to_string(); // Strip trailing '.git'
+
+        Ok(Self { host, name })
+    }
+}
+
+impl Display for RepoIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.host, self.name)
+    }
+}
+
+/// Manifests store how many shards were used when an export was created so that clients can know what to fetch.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExportManifest {
+    pub(crate) shard_count: usize,
+}
+
+/// Container for keys and values,
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Export {
+    pub(crate) shard_index: usize,
+    pub(crate) shard_count: usize,
+    pub(crate) items: Vec<(NamespacedKey, Value)>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Key {
+    CommitToBuildGraphHash {
+        #[serde(with = "hex::serde")]
+        commit_id: Vec<u8>,
+    },
+    OptionalProjectPatternSet {
+        #[serde(with = "hex::serde")]
+        build_graph_hash: Vec<u8>,
+        project_name: String,
+    },
+    ImportReceipt {
+        build_graph_hash: Vec<u8>,
+    },
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Key::CommitToBuildGraphHash { commit_id } => {
+                write!(
+                    f,
+                    "commit-to-build-graph-hash:commit={}",
+                    hex::encode(commit_id)
+                )
+            }
+            Key::OptionalProjectPatternSet {
+                build_graph_hash,
+                project_name,
+            } => {
+                write!(
+                    f,
+                    "optional-project-pattern-set:build-graph-hash={}:project={}",
+                    hex::encode(build_graph_hash),
+                    project_name
+                )
+            }
+            Key::ImportReceipt { build_graph_hash } => {
+                write!(
+                    f,
+                    "import_reciept:build-graph-hash={}",
+                    hex::encode(build_graph_hash),
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Value {
+    BuildGraphHash {
+        #[serde(with = "hex::serde")]
+        build_graph_hash: Vec<u8>,
+    },
+    MandatoryProjectPatternSet(PatternSet),
+    OptionalProjectPatternSet(PatternSet),
+    ImportReceiptIota,
+}
+
+/// Namespaced project cache keys act as an envelope identifying the repository cached content corresponds to.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamespacedKey {
+    pub(crate) repository: RepoIdentifier,
+    pub(crate) underlying: Key,
+    pub(crate) version: usize,
+}
+// TODO: Consider removing these namespaced keys because they are now redundant
+
+impl TryInto<String> for NamespacedKey {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<String, Self::Error> {
+        Ok(format!(
+            "{};{}{}",
+            self.repository,
+            self.underlying,
+            super::VERSION_KEY_SUFFIX.as_str()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_repository_identifier_from_url() {
+        assert_eq!(
+            RepoIdentifier::try_from(Url::from_str("https://github.com/twitter/focus").unwrap())
+                .unwrap(),
+            RepoIdentifier {
+                host: String::from("github.com"),
+                name: String::from("twitter/focus"),
+            }
+        );
+
+        assert_eq!(
+            RepoIdentifier::try_from(
+                Url::from_str("https://github.com/twitter/focus.git").unwrap()
+            )
+            .unwrap(),
+            RepoIdentifier {
+                host: String::from("github.com"),
+                name: String::from("twitter/focus"),
+            }
+        );
+
+        assert_eq!(
+            RepoIdentifier::try_from(
+                Url::from_str("https://github.com/twitter/focus.git").unwrap()
+            )
+            .unwrap(),
+            RepoIdentifier {
+                host: String::from("github.com"),
+                name: String::from("twitter/focus"),
+            }
+        );
+
+        assert_eq!(
+            RepoIdentifier::try_from(Url::from_str("file:///home/alice/code/focus.git").unwrap())
+                .unwrap(),
+            RepoIdentifier {
+                host: String::from("localhost"),
+                name: String::from("home/alice/code/focus"),
+            }
+        );
+    }
+}

--- a/focus/internals/src/lib/project_cache/remote.rs
+++ b/focus/internals/src/lib/project_cache/remote.rs
@@ -1,0 +1,134 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+
+use serde::{de::DeserializeOwned, Serialize};
+use url::Url;
+
+use super::*;
+
+pub trait ProjectCacheBackend {
+    // Fetch a model from the given URL and decode it from its JSON representation.
+    fn load_model(&self, url: Url) -> Result<Vec<u8>>;
+
+    fn store(&self, url: Url, value: Vec<u8>) -> Result<()>;
+
+    fn endpoint(&self) -> Url;
+}
+
+pub trait ProjectCacheBackendInternal: Sync + Send {}
+
+fn manifest_path(backend: &dyn ProjectCacheBackend, build_graph_hash: &Vec<u8>) -> Url {
+    let mut url = backend.endpoint();
+    let path = format!(
+        "{}/{}.manifest_v{}.json",
+        url.path(),
+        hex::encode(&build_graph_hash).as_str(),
+        PROJECT_CACHE_VERSION,
+    );
+    url.set_path(&path);
+    url
+}
+
+fn export_path(
+    backend: &dyn ProjectCacheBackend,
+    build_graph_hash: &Vec<u8>,
+    shard_index: usize,
+    shard_count: usize,
+) -> Url {
+    let mut url = backend.endpoint();
+    let path = format!(
+        "{}/{}_{}_{}.export_v{}.json",
+        url.path(),
+        hex::encode(&build_graph_hash).as_str(),
+        shard_index + 1,
+        shard_count,
+        PROJECT_CACHE_VERSION,
+    );
+    url.set_path(&path);
+    url
+}
+
+/// Load and deserialize a model from the given backend.
+fn load_model<T>(backend: &dyn ProjectCacheBackend, url: Url) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    backend
+        .load_model(url)
+        .and_then(|value| serde_json::from_slice(&value).map_err(anyhow::Error::new))
+}
+
+/// Serialize and store a model to the given backend.
+fn store_model<T>(backend: &dyn ProjectCacheBackend, url: Url, value: &T) -> Result<()>
+where
+    T: Serialize,
+{
+    serde_json::to_vec(value)
+        .map_err(anyhow::Error::new)
+        .and_then(|v| backend.store(url, v))
+}
+
+/// Fetch all exports for the given build graph hash by reading the manifest and fetching each shard.
+pub fn fetch_exports(
+    backend: &dyn ProjectCacheBackend,
+    build_graph_hash: &Vec<u8>,
+) -> Result<Vec<Export>> {
+    let span = tracing::info_span!("Fetching project cache data");
+    let _guard = span.enter();
+    // Fetch the manifest to determine how many shards there are.
+    let manifest: ExportManifest = load_model(backend, manifest_path(backend, build_graph_hash))?;
+    let mut exports = Vec::<Export>::with_capacity(manifest.shard_count);
+
+    for shard_index in 0..manifest.shard_count {
+        let export = load_model(
+            backend,
+            export_path(backend, build_graph_hash, shard_index, manifest.shard_count),
+        )
+        .with_context(|| {
+            format!(
+                "Failed to fetch shard {} of {}",
+                shard_index + 1,
+                manifest.shard_count
+            )
+        })?;
+        exports.push(export);
+    }
+
+    Ok(exports)
+}
+
+/// Store an export to the given backend, writing a manifest explaining how many shards were produced if one has not been written. Fails if the shard count does not agree.
+pub fn store_export(
+    backend: &dyn ProjectCacheBackend,
+    build_graph_hash: &Vec<u8>,
+    manifest: &ExportManifest,
+    export: &Export,
+) -> Result<()> {
+    let manifest_path = manifest_path(backend, build_graph_hash);
+    let span = tracing::info_span!("Uploading project cache manifest");
+    let _guard = span.enter();
+    if let Ok(existing_manifest) = load_model::<ExportManifest>(backend, manifest_path.clone()) {
+        // If a manifest exists, make sure that it is identical.
+        if manifest.ne(&existing_manifest) {
+            tracing::warn!(new_manifest = ?manifest, ?existing_manifest, "Manifests differ");
+            bail!("Previously uploaded manifest does not match the local manifest");
+        }
+    } else {
+        // Upload a manifest since it does not exist.
+        store_model(backend, manifest_path, manifest).context("Failed to upload manifest")?;
+    }
+
+    store_model(
+        backend,
+        export_path(
+            backend,
+            build_graph_hash,
+            export.shard_index,
+            export.shard_count,
+        ),
+        export,
+    )
+    .context("Failed to store export")
+}

--- a/focus/internals/src/lib/storage/mod.rs
+++ b/focus/internals/src/lib/storage/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context;
+use rocksdb::{DBCompressionType, Options, DB};
+use std::{path::Path, time::Duration};
+
+pub fn open_database(path: impl AsRef<Path>, ttl: Duration) -> anyhow::Result<DB> {
+    let path = path.as_ref();
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    // Compression settings from https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#compression
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    DB::open_with_ttl(&opts, path, ttl)
+        .with_context(|| format!("Opening database at {}", path.display()))
+        .map_err(|e| anyhow::anyhow!(e))
+}

--- a/focus/migrations/Cargo.toml
+++ b/focus/migrations/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 focus-internals = { path = "../internals" }
 focus-operations = { path = "../operations" }
-git2 = "0.14.2"
+git2 = { version = "0.14.2", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 lazy_static = "1.4.0"
 serde = "1.0.130"
 serde_derive = "1.0.130"

--- a/focus/operations/Cargo.toml
+++ b/focus/operations/Cargo.toml
@@ -16,7 +16,7 @@ dirs = "4.0.0"
 focus-internals = { path = "../internals" }
 focus-platform = { path = "../platform" }
 focus-util = { path = "../util" }
-git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "52716b2148888cf9a3b605eed9414544c12a778f", features = [
+git2 = { version = "0.14.2", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/operations/Cargo.toml
+++ b/focus/operations/Cargo.toml
@@ -16,7 +16,10 @@ dirs = "4.0.0"
 focus-internals = { path = "../internals" }
 focus-platform = { path = "../platform" }
 focus-util = { path = "../util" }
-git2 = "0.14.2"
+git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "52716b2148888cf9a3b605eed9414544c12a778f", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 humantime = "2.1.0"
 lazy_static = "1.4.0"
 maplit = "1.0.2"

--- a/focus/operations/src/lib.rs
+++ b/focus/operations/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ensure_clean;
 pub mod event;
 pub mod index;
 pub mod maintenance;
+pub mod project_cache;
 pub mod pull;
 pub mod refs;
 pub mod repo;

--- a/focus/operations/src/project_cache.rs
+++ b/focus/operations/src/project_cache.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::{Context, Result};
+use focus_internals::{model::repo::Repo, project_cache::ProjectCache};
+use focus_util::app::{App, ExitCode};
+
+pub fn push(
+    app: Arc<App>,
+    sparse_repo: impl AsRef<Path>,
+    commit: String,
+    shard_index: usize,
+    shard_count: usize,
+) -> Result<ExitCode> {
+    if shard_index >= shard_count {
+        anyhow::bail!("Shard index too high -- note that shard index is based at zero!")
+    }
+    if shard_count == 0 {
+        anyhow::bail!("Shard count must be greater than zero!");
+    }
+
+    let repo = Repo::open(sparse_repo.as_ref(), app.clone())?;
+    let object = repo
+        .underlying()
+        .revparse_single(&commit)
+        .with_context(|| format!("Resolving commit {commit}"))?;
+    let commit = object.as_commit().expect("Object was not a commit");
+    let endpoint = repo
+        .get_project_cache_remote_endpoint()?
+        .ok_or_else(|| anyhow::anyhow!("Project cache remote endpoint not configured"))?;
+
+    let cache = ProjectCache::new(&repo, endpoint, app)?;
+    let keys = cache
+        .generate_all(commit.id(), shard_index, shard_count)
+        .context("Generating project cache data failed")?;
+    let (_, build_graph_hash) = cache.get_build_graph_hash(commit.id(), true)?;
+
+    cache
+        .generate_and_push(&keys, &build_graph_hash, shard_index, shard_count)
+        .context("Export failed")?;
+
+    Ok(ExitCode(0))
+}

--- a/focus/operations/src/testing/mod.rs
+++ b/focus/operations/src/testing/mod.rs
@@ -12,3 +12,6 @@ pub mod repo;
 
 #[cfg(test)]
 pub mod sync;
+
+#[cfg(test)]
+pub mod sync_with_project_cache;

--- a/focus/operations/src/testing/sync.rs
+++ b/focus/operations/src/testing/sync.rs
@@ -13,7 +13,7 @@ use focus_testing::init_logging;
 use focus_util::app;
 
 use crate::{
-    sync::{SyncMode, SyncStatus},
+    sync::{SyncMechanism, SyncMode, SyncStatus},
     testing::integration::{RepoDisposition, RepoPairFixture},
 };
 
@@ -68,11 +68,12 @@ fn sync_upstream_changes() -> Result<()> {
     );
 
     // Sync in the sparse repo
-    crate::sync::run(
+    let sync_result = crate::sync::run(
         &fixture.sparse_repo_path,
         SyncMode::Normal,
         fixture.app.clone(),
     )?;
+    assert_eq!(sync_result.mechanism, SyncMechanism::Outline);
 
     let x_dir = fixture.sparse_repo_path.join("x");
     assert!(!x_dir.is_dir());
@@ -329,6 +330,7 @@ fn sync_skips_checkout_with_unchanged_profile() -> Result<()> {
     assert_snapshot!(original_profile_contents);
     assert_eq!(&original_profile_contents, &updated_profile_contents);
     assert!(!sync_result.checked_out);
+    assert_eq!(sync_result.mechanism, SyncMechanism::Outline);
 
     Ok(())
 }

--- a/focus/operations/src/testing/sync_with_project_cache.rs
+++ b/focus/operations/src/testing/sync_with_project_cache.rs
@@ -1,0 +1,141 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use focus_internals::model::repo::PROJECT_CACHE_ENDPOINT_CONFIG_KEY;
+use focus_testing::init_logging;
+use focus_util::{app::ExitCode, git_helper};
+
+use crate::{
+    project_cache,
+    sync::{SyncMechanism, SYNC_FROM_PROJECT_CACHE_REQUIRED_ERROR_MESSAGE},
+    testing::integration::RepoPairFixture,
+};
+
+struct Fixture {
+    underlying: RepoPairFixture,
+}
+
+impl Fixture {
+    fn new() -> Result<Self> {
+        let underlying = RepoPairFixture::new()?;
+        underlying.perform_clone()?;
+        Ok(Self { underlying })
+    }
+
+    fn configure_endpoint(&self) -> Result<()> {
+        let path = self.underlying.dir.path().join("project_cache_db");
+        std::fs::create_dir_all(&path)?;
+        git_helper::write_config(
+            &self.underlying.sparse_repo_path,
+            PROJECT_CACHE_ENDPOINT_CONFIG_KEY,
+            format!("file://{}", path.display()).as_str(),
+            self.underlying.app.clone(),
+        )?;
+        Ok(())
+    }
+
+    fn generate_content(&self, shard_count: usize) -> Result<()> {
+        let app = self.underlying.app.clone();
+
+        for shard_index in 0..shard_count {
+            let exit_code = project_cache::push(
+                app.clone(),
+                &self.underlying.sparse_repo_path,
+                String::from("HEAD"),
+                shard_index,
+                shard_count,
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to generate content for shard {} of {}",
+                    shard_index + 1,
+                    shard_count
+                )
+            })?;
+            if exit_code != ExitCode(0) {
+                bail!(
+                    "Non-zero exit while generating content for shard {} of {}",
+                    shard_index + 1,
+                    shard_count
+                )
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn generation() -> Result<()> {
+    init_logging();
+
+    let fixture = Fixture::new()?;
+    fixture.configure_endpoint()?;
+    fixture.generate_content(2)?;
+
+    Ok(())
+}
+
+#[test]
+fn project_cache_falls_back_with_non_project_targets_selected() -> Result<()> {
+    init_logging();
+
+    let fixture = Fixture::new()?;
+    let app = fixture.underlying.app.clone();
+    fixture.configure_endpoint()?;
+
+    // Add a project and a directory target to the selection
+    crate::selection::add(
+        &fixture.underlying.sparse_repo_path,
+        false,
+        vec![
+            String::from("team_banzai/project_a"),
+            String::from("directory:w_dir"),
+        ],
+        app.clone(),
+    )?;
+
+    // Verify that syncing with the project cache fails
+    match crate::sync::run(
+        &fixture.underlying.sparse_repo_path,
+        crate::sync::SyncMode::RequireProjectCache,
+        app,
+    ) {
+        Err(e) => {
+            let error_string = e.to_string();
+            assert!(error_string.contains(SYNC_FROM_PROJECT_CACHE_REQUIRED_ERROR_MESSAGE))
+        }
+        Ok(_) => bail!("Expected an error!"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn project_cache_answers_with_only_projects_selected() -> Result<()> {
+    init_logging();
+
+    let fixture = Fixture::new()?;
+    let app = fixture.underlying.app.clone();
+    fixture.configure_endpoint()?;
+    fixture.generate_content(2)?;
+
+    // Add a project and a directory target to the selection
+    crate::selection::add(
+        &fixture.underlying.sparse_repo_path,
+        true,
+        vec![String::from("team_banzai/project_a")],
+        app.clone(),
+    )?;
+
+    // Verify that syncing with the project cache fails
+    let result = crate::sync::run(
+        &fixture.underlying.sparse_repo_path,
+        crate::sync::SyncMode::RequireProjectCache,
+        app,
+    )?;
+    assert_eq!(result.mechanism, SyncMechanism::ProjectCache);
+
+    Ok(())
+}

--- a/focus/testing/Cargo.toml
+++ b/focus/testing/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 assert_cmd = "2.0.4"
-git2 = "0.14.2"
+git2 = { version = "0.14.2", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 tempfile = "3.2.0"
 termion = "1.5.6"
 tracing = "0.1.31"

--- a/focus/tracing/Cargo.toml
+++ b/focus/tracing/Cargo.toml
@@ -10,7 +10,10 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0.0"
 focus-testing = { path = "../testing" }
 focus-util = { path = "../util" }
-git2 = "0.14.2"
+git2 = { version = "0.14.2", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 heck = "0.4.0"
 lazy_static = "1.4.0"
 nix = "0.23.0"

--- a/focus/util/Cargo.toml
+++ b/focus/util/Cargo.toml
@@ -10,7 +10,10 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0.0"
 filetime = "0.2"
 focus-testing = { path = "../testing" }
-git2 = "0.14.2"
+git2 = { version = "0.14.2", features = [
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 lazy_static = "1.4.0"
 nix = "0.23.0"
 once_cell = "1.4.0"

--- a/focus/util/src/git_helper.rs
+++ b/focus/util/src/git_helper.rs
@@ -598,7 +598,7 @@ fn get_changed_paths_between_trees_internal(
             match repo.find_tree(oid) {
                 Ok(tree) => Ok(tree),
                 Err(err) => {
-                    return Err(anyhow!(
+                    Err(anyhow!(
                         "Tree entry {oid:?} was said to be an object of kind tree, but it could not be looked up: {err}",
                     ))
                 }


### PR DESCRIPTION
The project cache allows for faster syncing by utilizing a coarse-grained cache keyed on a project at given build graph state, returning pattern sets used to reconstitute a sparse profile.

See `focus/doc/project_cache.md` in this commit for an in-depth overview of how this works.