### PR TITLE
Refactor project definition to move projects from the 'targets' field…

### DIFF
--- a/focus/internals/src/lib/model/selection/selection.rs
+++ b/focus/internals/src/lib/model/selection/selection.rs
@@ -398,10 +398,8 @@ mod testing {
             name: PROJECT_NAME_STR.to_owned(),
             description: String::from("This is a description"),
             mandatory: false,
-            targets: btreeset![
-                String::from("bazel://a:b"),
-                String::from(PROJECT_NAME_STR_2)
-            ],
+            targets: btreeset![String::from("bazel://a:b"),],
+            projects: btreeset![String::from(PROJECT_NAME_STR_2)],
         }
     }
 


### PR DESCRIPTION
Depends on earlier PR, https://github.com/twitter/focus/pull/26
I didn't go and update all of the downstream users of Project, notably display functions because i don't know in what context they are run. Don't think there will be any functionality bugs though, just maybe some unimplemented UI features.