### PR TITLE
Adding flags to 'focus status' for use with 'bazel idea'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ version = "0.5.7"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap 3.2.20",
  "content-addressed-cache",
  "criterion",
  "crossbeam",

--- a/focus/commands/src/cli/main.rs
+++ b/focus/commands/src/cli/main.rs
@@ -24,7 +24,7 @@ use focus_util::{
     time::FocusTime,
 };
 
-use focus_internals::tracker::Tracker;
+use focus_internals::{target::TargetTypes, tracker::Tracker};
 use focus_operations::{
     clone::{CloneArgs, ClonedRepoTemplate},
     maintenance::{self, ScheduleOpts},
@@ -109,7 +109,15 @@ enum Subcommand {
     },
 
     /// Display which projects and targets are selected.
-    Status {},
+    Status {
+        ///Unwrap all projects until only targets are displayed
+        #[clap(long = "targets")]
+        targets: bool,
+
+        //Include only the types of targets specified
+        #[clap(short = 't', long = "types", arg_enum)]
+        target_types: Vec<TargetTypes>,
+    },
 
     /// List available projects.
     Projects {},
@@ -932,9 +940,12 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
             Ok(ExitCode(0))
         }
 
-        Subcommand::Status {} => {
+        Subcommand::Status {
+            targets,
+            target_types,
+        } => {
             let sparse_repo = paths::find_repo_root_from(app.clone(), std::env::current_dir()?)?;
-            focus_operations::status::run(&sparse_repo, app)
+            focus_operations::status::run(&sparse_repo, app, targets, target_types)
         }
 
         Subcommand::Projects {} => {

--- a/focus/internals/Cargo.toml
+++ b/focus/internals/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "3.1.7", features = ["derive", "env", "wrap_help"] }
 content-addressed-cache = { path = "../../content-addressed-cache" }
 crossbeam = "0.8.2"
 dirs = "4.0.0"

--- a/focus/internals/src/lib/model/selection/mod.rs
+++ b/focus/internals/src/lib/model/selection/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod project;
+pub use project::resolve_targets_for_project;
 pub use project::Project;
 pub(crate) use project::ProjectCatalog;
 use project::ProjectIndex;

--- a/focus/internals/src/lib/model/selection/selection.rs
+++ b/focus/internals/src/lib/model/selection/selection.rs
@@ -279,9 +279,11 @@ impl SelectionManager {
         let optional_projects = &self.project_catalog().optional_projects.underlying;
         let mut target_set = selection.targets.clone();
         let projects = selection.projects;
-        for project in projects {
-            target_set.extend(project.resolve_targets_for_project(optional_projects)?);
-        }
+
+        target_set.extend(resolve_targets_for_project(
+            projects.into_iter().collect(),
+            optional_projects,
+        )?);
 
         Ok(target_set)
     }

--- a/focus/internals/src/lib/target.rs
+++ b/focus/internals/src/lib/target.rs
@@ -11,6 +11,13 @@ use thiserror::Error;
 
 pub type TargetSet = HashSet<Target>;
 
+#[derive(clap::ArgEnum, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum TargetTypes {
+    Bazel,
+    Directory,
+    Pants,
+}
+
 #[derive(Serialize, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
 pub enum Target {
     /// A Bazel package like `//foo/bar:baz`.

--- a/focus/operations/src/status.rs
+++ b/focus/operations/src/status.rs
@@ -2,15 +2,52 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use focus_internals::model::repo::Repo;
+use focus_internals::{model::repo::Repo, target::TargetTypes};
 use focus_util::app::{App, ExitCode};
-use std::{path::Path, sync::Arc};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
-pub fn run(sparse_repo: impl AsRef<Path>, app: Arc<App>) -> Result<ExitCode> {
+pub fn run(
+    sparse_repo: impl AsRef<Path>,
+    app: Arc<App>,
+    targets_flag: bool,
+    target_types: Vec<TargetTypes>,
+) -> Result<ExitCode> {
+    let target_types = HashSet::<TargetTypes>::from_iter(target_types.iter().cloned());
     let repo = Repo::open(sparse_repo.as_ref(), app)?;
     let selections = repo.selection_manager()?;
     let selection = selections.selection()?;
-    println!("{}", selection);
+    if target_types.is_empty() && !targets_flag {
+        println!("{}", selection);
+    } else {
+        let mut targets = selection.targets;
+        if !targets_flag {
+            for project in selection.projects {
+                println!("{}", project.name)
+            }
+        } else {
+            targets = selections.compute_complete_target_set()?;
+        }
+
+        for target in targets {
+            match target {
+                focus_internals::target::Target::Bazel(_) => {
+                    if target_types.contains(&TargetTypes::Bazel) {
+                        println!("{}", target);
+                    }
+                }
+                focus_internals::target::Target::Directory(_) => {
+                    if target_types.contains(&TargetTypes::Directory) {
+                        println!("{}", target);
+                    }
+                }
+                focus_internals::target::Target::Pants(_) => {
+                    if target_types.contains(&TargetTypes::Pants) {
+                        println!("{}", target);
+                    }
+                }
+            }
+        }
+    }
 
     Ok(ExitCode(0))
 }


### PR DESCRIPTION
Example output:
```
[tw-mbp-dbernadett foso (master|SPARSE)]% focus.devb status --targets -t bazel 2>/dev/null
bazel://vm-team/jdk11-migration/...
bazel://twitter-server/...
bazel://strato/src/main/scala/com/twitter/strato/logging/...
bazel://tools/scripts/...
bazel://gizmoduck-thrift/tools/...
bazel://schema-evolution:persisted-schema-checker
bazel://strato/src/main/scala/com/twitter/strato/incremental:incremental
bazel://src/python/twitter/devprod/ci/ci_job_builder/...
bazel://tools/src/main/...
bazel://scoot/sickle:sickle
bazel://loglens/loglens-logging/...
bazel://tools/implicit_deps/...
bazel://strato/src/main/scala/com/twitter/strato/cmd/compiler:ql-and-client-compiler
bazel://src/python/twitter/source_eng/source_init:source-init
bazel://src/python/twitter/strato/stage/services:strato
bazel://streamertail/...
bazel://scrooge/scrooge-linter/...
bazel://strato/bin/...
bazel://scrooge/scrooge-generator/...
```