### PR TITLE
Adding a --unroll flag to 'focus add'

### DIFF
--- a/focus/commands/src/cli/main.rs
+++ b/focus/commands/src/cli/main.rs
@@ -99,6 +99,10 @@ enum Subcommand {
         /// search results.
         #[clap(short = 'a', long = "all", requires("interactive"))]
         search_all_targets: bool,
+
+        /// Add the immediate targets and projects of projects to the selection, not the projects themselves.
+        #[clap(long = "unroll")]
+        unroll: bool,
     },
 
     /// Remove projects and targets from the selection.
@@ -910,6 +914,7 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
             projects_and_targets,
             interactive,
             search_all_targets,
+            unroll,
         } => {
             let sparse_repo = paths::find_repo_root_from(app.clone(), std::env::current_dir()?)?;
             paths::assert_focused_repo(&sparse_repo)?;
@@ -922,9 +927,16 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
                     &sparse_repo,
                     app,
                     search_all_targets,
+                    unroll,
                 )?;
             } else {
-                focus_operations::selection::add(&sparse_repo, true, projects_and_targets, app)?;
+                focus_operations::selection::add(
+                    &sparse_repo,
+                    true,
+                    projects_and_targets,
+                    unroll,
+                    app,
+                )?;
             }
             Ok(ExitCode(0))
         }

--- a/focus/fixtures/repos/bazel_java_example/focus/projects/project_c.projects.json
+++ b/focus/fixtures/repos/bazel_java_example/focus/projects/project_c.projects.json
@@ -1,0 +1,14 @@
+{
+    "projects": [
+        {
+            "name": "team_zissou/project_c",
+            "description": "Stuff relating to project C",
+            "targets": [
+                "bazel://project_b/..."
+            ],
+            "projects": [
+                "team_banzai/project_a"
+            ]
+        }
+    ]
+}

--- a/focus/operations/src/testing/sync.rs
+++ b/focus/operations/src/testing/sync.rs
@@ -83,6 +83,7 @@ fn sync_upstream_changes() -> Result<()> {
         &fixture.sparse_repo_path,
         true,
         vec![String::from("bazel://x/...")],
+        false,
         fixture.app.clone(),
     )?;
 
@@ -164,6 +165,7 @@ fn sync_layer_manipulation() -> Result<()> {
         &path,
         true,
         vec![project_b_label.clone()],
+        false,
         fixture.app.clone(),
     )?;
     {
@@ -181,6 +183,7 @@ fn sync_layer_manipulation() -> Result<()> {
         &path,
         true,
         vec![project_a_label.clone()],
+        false,
         fixture.app.clone(),
     )?;
     {
@@ -231,6 +234,7 @@ fn sync_adhoc_manipulation() -> Result<()> {
         &fixture.sparse_repo_path,
         true,
         targets.clone(),
+        false,
         fixture.app.clone(),
     )?;
     assert!(library_b_dir.is_dir());
@@ -260,6 +264,7 @@ fn failed_selection_mutations_are_reverted() -> Result<()> {
         &fixture.sparse_repo_path,
         true,
         targets,
+        false,
         fixture.app.clone()
     )
     .is_err());
@@ -317,6 +322,7 @@ fn sync_skips_checkout_with_unchanged_profile() -> Result<()> {
         &fixture.sparse_repo_path,
         false, // Note: Manual sync
         targets,
+        false,
         fixture.app.clone(),
     )?;
     // First sync performs a checkout.
@@ -350,6 +356,7 @@ fn sync_sets_ti_client_correctly() -> Result<()> {
         &fixture.sparse_repo_path,
         true,
         targets.clone(),
+        false,
         fixture.app.clone(),
     )?;
 
@@ -453,6 +460,7 @@ fn regression_adding_directory_targets_present_in_mandatory_sets() -> Result<()>
         &fixture.sparse_repo_path,
         true,
         targets,
+        false,
         fixture.app.clone(),
     )?;
     assert!(swedish_txt_file.is_file());
@@ -488,6 +496,7 @@ fn regression_adding_deep_directory_target_materializes_correctly() -> Result<()
         &fixture.sparse_repo_path,
         true,
         targets,
+        false,
         fixture.app.clone(),
     )?;
 

--- a/focus/operations/src/testing/sync_with_project_cache.rs
+++ b/focus/operations/src/testing/sync_with_project_cache.rs
@@ -93,6 +93,7 @@ fn project_cache_falls_back_with_non_project_targets_selected() -> Result<()> {
             String::from("team_banzai/project_a"),
             String::from("directory:w_dir"),
         ],
+        false,
         app.clone(),
     )?;
 
@@ -126,6 +127,7 @@ fn project_cache_answers_with_only_projects_selected() -> Result<()> {
         &fixture.underlying.sparse_repo_path,
         true,
         vec![String::from("team_banzai/project_a")],
+        false,
         app.clone(),
     )?;
 


### PR DESCRIPTION
This command unrolls the first layer of projects. It is meant to help make changes to existing project definitions when a save feature becomes available.

Also added to the fixture to test the new feature.