### PR TITLE
Implement 'focus selection save'

### DIFF
--- a/focus/internals/src/lib/model/selection/selection.rs
+++ b/focus/internals/src/lib/model/selection/selection.rs
@@ -325,6 +325,9 @@ impl SelectionManager {
     pub fn project_catalog(&self) -> &ProjectCatalog {
         &self.project_catalog
     }
+    pub fn mut_project_catalog(&mut self) -> &mut ProjectCatalog {
+        &mut self.project_catalog
+    }
 }
 
 /// A structure to store the names of selected projects and targets. Converted from the fully-featured in-memory representation Selection.


### PR DESCRIPTION
This project implements `focus selection save`. It accepts a project name and optionally a file `root` to save to.

Includes tests of saving over an existing project, saving to a new file, and saving a new project to an existing file.