### PR TITLE
Update to a newer patched `git2-rs` (and underlying `libgit2`) crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,8 +1460,8 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "git2"
-version = "0.14.2"
-source = "git+https://github.com/bierbaum/git2-rs?rev=52716b2148888cf9a3b605eed9414544c12a778f#52716b2148888cf9a3b605eed9414544c12a778f"
+version = "0.15.0"
+source = "git+https://github.com/bierbaum/git2-rs?rev=a03dc826f17e668454a76150b9f5fbddda5297da#a03dc826f17e668454a76150b9f5fbddda5297da"
 dependencies = [
  "bitflags",
  "libc",
@@ -1795,8 +1795,8 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.2+1.4.2"
-source = "git+https://github.com/bierbaum/git2-rs?rev=52716b2148888cf9a3b605eed9414544c12a778f#52716b2148888cf9a3b605eed9414544c12a778f"
+version = "0.14.0+1.5.0"
+source = "git+https://github.com/bierbaum/git2-rs?rev=a03dc826f17e668454a76150b9f5fbddda5297da#a03dc826f17e668454a76150b9f5fbddda5297da"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ members = [
 ]
 
 [patch.crates-io]
-git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "52716b2148888cf9a3b605eed9414544c12a778f" }
+git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "a03dc826f17e668454a76150b9f5fbddda5297da" }

--- a/content-addressed-cache/Cargo.toml
+++ b/content-addressed-cache/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.56"
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/commands/Cargo.toml
+++ b/focus/commands/Cargo.toml
@@ -15,7 +15,7 @@ focus-operations = { path = "../operations" }
 focus-testing = { path = "../testing" }
 focus-tracing = { path = "../tracing" }
 focus-util = { path = "../util" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/internals/Cargo.toml
+++ b/focus/internals/Cargo.toml
@@ -12,7 +12,7 @@ content-addressed-cache = { path = "../../content-addressed-cache" }
 crossbeam = "0.8.2"
 dirs = "4.0.0"
 focus-util = { path = "../util" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/migrations/Cargo.toml
+++ b/focus/migrations/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 focus-internals = { path = "../internals" }
 focus-operations = { path = "../operations" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/operations/Cargo.toml
+++ b/focus/operations/Cargo.toml
@@ -16,7 +16,7 @@ dirs = "4.0.0"
 focus-internals = { path = "../internals" }
 focus-platform = { path = "../platform" }
 focus-util = { path = "../util" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/operations/src/maintenance/mod.rs
+++ b/focus/operations/src/maintenance/mod.rs
@@ -331,18 +331,18 @@ impl Runner<'_> {
     }
 
     fn get_repo_paths_from_config(&self) -> Result<Vec<PathBuf>> {
-        let entries = self.config.multivar(&self.config_key, None)?;
-        let vec_entries: Vec<git2::ConfigEntry> = entries
+        Ok(self
+            .config
+            .multivar_values(&self.config_key, None)
+            .with_context(|| {
+                format!(
+                    "Failed reading values for config key '{}'",
+                    &self.config_key
+                )
+            })?
             .into_iter()
-            .collect::<Result<Vec<git2::ConfigEntry>, git2::Error>>()?;
-
-        let paths = vec_entries
-            .into_iter()
-            .filter_map(|v| v.value().map(|x| x.to_owned()))
             .map(PathBuf::from)
-            .collect();
-
-        Ok(paths)
+            .collect())
     }
 
     fn get_repo_paths_from_tracker(&self) -> Result<Vec<PathBuf>> {

--- a/focus/testing/Cargo.toml
+++ b/focus/testing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.45", features = ["backtrace"] }
 assert_cmd = "2.0.4"
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/tracing/Cargo.toml
+++ b/focus/tracing/Cargo.toml
@@ -10,7 +10,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0.0"
 focus-testing = { path = "../testing" }
 focus-util = { path = "../util" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/util/Cargo.toml
+++ b/focus/util/Cargo.toml
@@ -10,7 +10,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0.0"
 filetime = "0.2"
 focus-testing = { path = "../testing" }
-git2 = { version = "0.14.2", features = [
+git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }

--- a/focus/util/src/git_helper.rs
+++ b/focus/util/src/git_helper.rs
@@ -463,9 +463,9 @@ impl ConfigExt for git2::Config {
 
         let mut values: Vec<String> = Vec::new();
 
-        for config_entry_r in configs.into_iter() {
-            values.push(config_entry_r?.value().unwrap().to_owned());
-        }
+        configs.for_each(|entry| {
+            values.push(entry.value().unwrap().to_owned());
+        })?;
 
         Ok(values)
     }
@@ -508,13 +508,12 @@ impl ConfigExt for git2::Config {
         let entries = self.entries(glob)?;
         let mut result: Vec<(String, String)> = Vec::new();
 
-        for entry in entries.into_iter() {
-            let entry = entry?;
-            match (entry.name(), entry.value()) {
-                (Some(name), Some(value)) => result.push((name.to_owned(), value.to_owned())),
-                _ => continue,
+        entries.for_each(|entry| {
+            if let (Some(name), Some(value)) = (entry.name(), entry.value()) {
+                result.push((name.to_owned(), value.to_owned()));
             }
-        }
+        })?;
+
         Ok(result)
     }
 


### PR DESCRIPTION
- The `git2-rs` crate has been upgraded to 0.15 patched to use our patched `libgit2`
- The underlying `libgit2` has been upgraded to v1.5.0 with the worktree config patches (from https://github.com/vermiculus/libgit2/tree/sallred/support-worktree-config) applied