### PR TITLE
Use snapshots to allow sync in repos that have pending changes to their tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "filetime",
  "focus-testing",
  "git2",
+ "hex 0.4.3",
  "insta",
  "lazy_static",
  "nix 0.23.1",
@@ -1300,6 +1301,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tar",
  "tempfile",
  "termion",
  "tool-insights-client",
@@ -3227,6 +3229,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4141,6 +4154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "event-listener",
  "futures-core",
 ]
@@ -116,15 +116,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.0.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -136,7 +136,7 @@ checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg 1.1.0",
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "futures-lite",
  "libc",
  "log",
@@ -352,9 +352,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -509,6 +509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -720,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -732,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -747,15 +756,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1447,7 +1456,7 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 [[package]]
 name = "git2"
 version = "0.15.0"
-source = "git+https://github.com/bierbaum/git2-rs?rev=a03dc826f17e668454a76150b9f5fbddda5297da#a03dc826f17e668454a76150b9f5fbddda5297da"
+source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#fc68506764d070dbd23a0cf87db962d8422d9eeb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1576,9 +1585,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1782,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "libgit2-sys"
 version = "0.14.0+1.5.0"
-source = "git+https://github.com/bierbaum/git2-rs?rev=a03dc826f17e668454a76150b9f5fbddda5297da#a03dc826f17e668454a76150b9f5fbddda5297da"
+source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#fc68506764d070dbd23a0cf87db962d8422d9eeb"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "termion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 [[package]]
 name = "git2"
 version = "0.15.0"
-source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#fc68506764d070dbd23a0cf87db962d8422d9eeb"
+source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#a190332f5d05260a283c35ef0aadb125e9a3fe78"
 dependencies = [
  "bitflags",
  "libc",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "libgit2-sys"
 version = "0.14.0+1.5.0"
-source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#fc68506764d070dbd23a0cf87db962d8422d9eeb"
+source = "git+https://github.com/bierbaum/git2-rs?tag=twttr-1.5#a190332f5d05260a283c35ef0aadb125e9a3fe78"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ members = [
 ]
 
 [patch.crates-io]
-git2 = { git = "https://github.com/bierbaum/git2-rs", rev = "a03dc826f17e668454a76150b9f5fbddda5297da" }
+git2 = { git = "https://github.com/bierbaum/git2-rs", tag = "twttr-1.5" }

--- a/content-addressed-cache/src/synchronizer.rs
+++ b/content-addressed-cache/src/synchronizer.rs
@@ -300,7 +300,7 @@ impl CacheSynchronizer for GitBackedCacheSynchronizer {
             &vec_of_prev_commit_references[..],
         )?;
 
-        let refspecs = vec![refspec_fmt(&self.namespace, &keyset_id)];
+        let refspecs = vec![refspec_fmt(&self.namespace, keyset_id)];
 
         self.repo
             .reference(
@@ -593,7 +593,7 @@ mod tests {
 
     #[test]
     pub fn refspec_formatting() {
-        assert_eq!(refspec_fmt("cache", &keyset_id_1()), String::from("+refs/tags/cache/abcd1abcd1abcd1abcd100000000000000000000:refs/tags/cache/abcd1abcd1abcd1abcd100000000000000000000"));
+        assert_eq!(refspec_fmt("cache", keyset_id_1()), String::from("+refs/tags/cache/abcd1abcd1abcd1abcd100000000000000000000:refs/tags/cache/abcd1abcd1abcd1abcd100000000000000000000"));
         assert_eq!(
             refspec_fmt("cache", "foo"),
             String::from("+refs/tags/cache/foo:refs/tags/cache/foo")
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     pub fn tag_formatting() {
         assert_eq!(
-            tag_fmt("cache", &keyset_id_1()),
+            tag_fmt("cache", keyset_id_1()),
             String::from("refs/tags/cache/abcd1abcd1abcd1abcd100000000000000000000"),
         );
         assert_eq!(tag_fmt("cache", "foo"), String::from("refs/tags/cache/foo"));

--- a/focus/commands/src/cli/main.rs
+++ b/focus/commands/src/cli/main.rs
@@ -30,7 +30,7 @@ use focus_operations::{
     maintenance::{self, ScheduleOpts},
     project::lint,
     selection::save,
-    sync::SyncMode,
+    sync::{SyncMode, SyncRequest},
 };
 use strum::VariantNames;
 use termion::{color, style};
@@ -848,7 +848,7 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
             } else {
                 SyncMode::Incremental
             };
-            focus_operations::sync::run(&sparse_repo, mode, app)?;
+            focus_operations::sync::run(&SyncRequest::new(&sparse_repo, mode), app)?;
             Ok(ExitCode(0))
         }
 

--- a/focus/commands/src/cli/main.rs
+++ b/focus/commands/src/cli/main.rs
@@ -972,9 +972,6 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
             let sparse_repo = paths::find_repo_root_from(app.clone(), std::env::current_dir()?)?;
             paths::assert_focused_repo(&sparse_repo)?;
             let _lock_file = hold_lock_file(&sparse_repo)?;
-            focus_operations::ensure_clean::run(&sparse_repo, app.clone())
-                .context("Ensuring working trees are clean failed")?;
-
             if interactive {
                 focus_operations::selection::add_interactive(
                     &sparse_repo,
@@ -1000,8 +997,6 @@ fn run_subcommand(app: Arc<App>, tracker: &Tracker, options: FocusOpts) -> Resul
         } => {
             let sparse_repo = paths::find_repo_root_from(app.clone(), std::env::current_dir()?)?;
             let _lock_file = hold_lock_file(&sparse_repo)?;
-            focus_operations::ensure_clean::run(&sparse_repo, app.clone())
-                .context("Ensuring working trees are clean failed")?;
             focus_operations::selection::remove(
                 &sparse_repo,
                 true,

--- a/focus/internals/src/lib/locking.rs
+++ b/focus/internals/src/lib/locking.rs
@@ -8,7 +8,7 @@ use std::{path::Path, sync::Arc};
 use focus_util::{app::App, git_helper, lock_file::LockFile};
 
 pub fn hold_lock(repo_path: &Path, file_name: &Path, app: Arc<App>) -> Result<LockFile> {
-    let git_dir = git_helper::git_dir(repo_path, app.clone())?;
+    let git_dir = git_helper::git_dir(repo_path, app)?;
     let focus_dir = git_dir.join(".focus");
     std::fs::create_dir_all(&focus_dir)?;
     let lock_path = focus_dir.join(file_name);

--- a/focus/internals/src/lib/locking.rs
+++ b/focus/internals/src/lib/locking.rs
@@ -3,12 +3,12 @@
 
 use anyhow::Result;
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
-use focus_util::{git_helper, lock_file::LockFile};
+use focus_util::{app::App, git_helper, lock_file::LockFile};
 
-pub fn hold_lock(repo_path: &Path, file_name: &Path) -> Result<LockFile> {
-    let git_dir = git_helper::git_dir(repo_path)?;
+pub fn hold_lock(repo_path: &Path, file_name: &Path, app: Arc<App>) -> Result<LockFile> {
+    let git_dir = git_helper::git_dir(repo_path, app.clone())?;
     let focus_dir = git_dir.join(".focus");
     std::fs::create_dir_all(&focus_dir)?;
     let lock_path = focus_dir.join(file_name);

--- a/focus/internals/src/lib/model/persistence.rs
+++ b/focus/internals/src/lib/model/persistence.rs
@@ -138,7 +138,7 @@ impl<T: Default + DeserializeOwned + Serialize> FileBackedCollection<T> {
         let path = self.make_path(name);
         debug!(?path, %name, "Insert");
         self.underlying.insert(name.to_owned(), entity.clone());
-        store_model(&path.as_path(), entity)
+        store_model(path.as_path(), entity)
     }
 
     /// Remove an entity by name from the `underlying` cache and erase it from disk.
@@ -179,7 +179,7 @@ impl<T: Default + DeserializeOwned + Serialize> FileBackedCollection<T> {
     {
         for (name, entity) in self.underlying.iter() {
             let path = self.make_path(name);
-            store_model(&path.as_path(), entity)
+            store_model(path.as_path(), entity)
                 .with_context(|| format!("Storing entity to {}", path.display()))?
         }
 
@@ -198,7 +198,7 @@ impl<T: Default + DeserializeOwned + Serialize> FileBackedCollection<T> {
             serde_json::to_string(entity)?,
             path.display()
         );
-        store_model(&path.as_path(), entity)
+        store_model(path.as_path(), entity)
             .with_context(|| format!("Storing entity to {}", path.display()))
     }
 }
@@ -226,8 +226,8 @@ mod tests {
         focus_testing::init_logging();
 
         let dir = tempfile::tempdir()?;
-        let mut collection = make_collection(&dir.path())?;
-        let mut alternate_collection = make_collection(&dir.path())?;
+        let mut collection = make_collection(dir.path())?;
+        let mut alternate_collection = make_collection(dir.path())?;
 
         let name = "jeff";
         collection.insert(
@@ -259,7 +259,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let name = "lebowski";
         {
-            let mut collection = make_collection(&dir.path())?;
+            let mut collection = make_collection(dir.path())?;
 
             collection.insert(
                 name,
@@ -287,7 +287,7 @@ mod tests {
         }
 
         {
-            let collection = make_collection(&dir.path())?;
+            let collection = make_collection(dir.path())?;
             let (actual_name, entity) = collection.underlying.iter().next().unwrap();
             assert_eq!(actual_name, name);
             assert_eq!(entity.name, "Maude Lebowski");
@@ -301,7 +301,7 @@ mod tests {
         focus_testing::init_logging();
         let dir = tempfile::tempdir()?;
         {
-            let mut collection = make_collection(&dir.path())?;
+            let mut collection = make_collection(dir.path())?;
             {
                 collection.underlying.insert(
                     String::from("foo"),
@@ -321,7 +321,7 @@ mod tests {
         }
 
         {
-            let collection = make_collection(&dir.path())?;
+            let collection = make_collection(dir.path())?;
             assert!(collection.underlying.contains_key("foo"));
             assert!(collection.underlying.contains_key("bar"));
         }

--- a/focus/internals/src/lib/model/repo.rs
+++ b/focus/internals/src/lib/model/repo.rs
@@ -791,7 +791,7 @@ impl Repo {
                 targets,
                 outlining_tree,
                 cache,
-                snapshot.clone(),
+                snapshot,
                 app.clone(),
             )
         } else {
@@ -799,7 +799,7 @@ impl Repo {
                 commit_id,
                 targets,
                 outlining_tree,
-                snapshot.clone(),
+                snapshot,
                 app.clone(),
             )
         }?;

--- a/focus/internals/src/lib/model/repo.rs
+++ b/focus/internals/src/lib/model/repo.rs
@@ -795,13 +795,7 @@ impl Repo {
                 app.clone(),
             )
         } else {
-            self.sync_one_shot(
-                commit_id,
-                targets,
-                outlining_tree,
-                snapshot,
-                app.clone(),
-            )
+            self.sync_one_shot(commit_id, targets, outlining_tree, snapshot, app.clone())
         }?;
 
         outline_patterns.extend(working_tree.default_working_tree_patterns()?);

--- a/focus/internals/src/lib/model/repo.rs
+++ b/focus/internals/src/lib/model/repo.rs
@@ -695,7 +695,7 @@ pub struct Repo {
 
 impl Repo {
     pub fn open(path: &Path, app: Arc<App>) -> Result<Self> {
-        let repo = git2::Repository::open(&path)
+        let repo = git2::Repository::open(path)
             .with_context(|| format!("Opening repo {}", path.display()))
             .context("Failed to open repo")?;
         if repo.is_bare() {

--- a/focus/internals/src/lib/model/repo.rs
+++ b/focus/internals/src/lib/model/repo.rs
@@ -777,7 +777,7 @@ impl Repo {
             .context("Configuring the outlining tree")?;
 
         let mut outline_patterns = if let Some(cache) = cache {
-            self.sync_incremental(commit_id, targets, outlining_tree, app.clone(), cache)
+            self.sync_incremental(commit_id, targets, outlining_tree, cache, app.clone())
         } else {
             self.sync_one_shot(commit_id, targets, outlining_tree, app.clone())
         }?;
@@ -820,8 +820,8 @@ impl Repo {
         commit_id: Oid,
         targets: &HashSet<Target>,
         outlining_tree: &OutliningTree,
-        app: Arc<App>,
         cache: &RocksDBCache,
+        app: Arc<App>,
     ) -> Result<PatternSet> {
         let index_config = &self.config().index;
         let commit = self

--- a/focus/internals/src/lib/project_cache/local_cache_backend.rs
+++ b/focus/internals/src/lib/project_cache/local_cache_backend.rs
@@ -42,7 +42,7 @@ impl LocalCacheBackend {
 impl ProjectCacheBackend for LocalCacheBackend {
     fn load_model(&self, url: Url) -> Result<Vec<u8>> {
         let key = url.path();
-        if let Ok(Some(repr)) = self.database.borrow().get(&key) {
+        if let Ok(Some(repr)) = self.database.borrow().get(key) {
             debug!(?key, "GET: Found");
             Ok(repr)
         } else {
@@ -55,7 +55,7 @@ impl ProjectCacheBackend for LocalCacheBackend {
         let key = url.path();
         debug!(?key, "PUT");
         self.database
-            .put(&key, value)
+            .put(key, value)
             .with_context(|| format!("Writing key '{}' failed", &key))
     }
 

--- a/focus/internals/src/lib/project_cache/remote.rs
+++ b/focus/internals/src/lib/project_cache/remote.rs
@@ -36,7 +36,7 @@ fn manifest_path(backend: &dyn ProjectCacheBackend, build_graph_hash: &Vec<u8>) 
     let path = format!(
         "{}/{}.manifest_v{}.json.gz",
         url.path(),
-        hex::encode(&build_graph_hash).as_str(),
+        hex::encode(build_graph_hash).as_str(),
         PROJECT_CACHE_VERSION,
     );
     url.set_path(&path);
@@ -53,7 +53,7 @@ fn export_path(
     let path = format!(
         "{}/{}_{}_{}.export_v{}.json.gz",
         url.path(),
-        hex::encode(&build_graph_hash).as_str(),
+        hex::encode(build_graph_hash).as_str(),
         shard_index + 1,
         shard_count,
         PROJECT_CACHE_VERSION,

--- a/focus/operations/benches/bench_sync.rs
+++ b/focus/operations/benches/bench_sync.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use focus_operations::sync::SyncRequest;
 use focus_util::app::App;
 
 pub fn bench_sync(c: &mut Criterion) {
@@ -15,8 +16,7 @@ pub fn bench_sync(c: &mut Criterion) {
 
     println!("Warming up with initial sync");
     focus_operations::sync::run(
-        &repo_path,
-        focus_operations::sync::SyncMode::Incremental,
+        &SyncRequest::new(&repo_path, focus_operations::sync::SyncMode::Incremental),
         app.clone(),
     )
     .unwrap();
@@ -26,8 +26,7 @@ pub fn bench_sync(c: &mut Criterion) {
     group.bench_function("focus_operations::sync::run", |b| {
         b.iter(|| {
             focus_operations::sync::run(
-                &repo_path,
-                focus_operations::sync::SyncMode::Incremental,
+                &SyncRequest::new(&repo_path, focus_operations::sync::SyncMode::Incremental),
                 app.clone(),
             )
             .unwrap()

--- a/focus/operations/src/background.rs
+++ b/focus/operations/src/background.rs
@@ -8,7 +8,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use focus_util::app::{App, ExitCode};
 
-use crate::sync::SyncMode;
+use crate::sync::{SyncMode, SyncRequest};
 
 pub fn enable(
     app: Arc<App>,
@@ -30,7 +30,7 @@ pub fn disable(app: Arc<App>, sparse_repo: PathBuf) -> anyhow::Result<ExitCode> 
 }
 
 pub fn sync(app: Arc<App>, sparse_repo: PathBuf) -> anyhow::Result<ExitCode> {
-    super::sync::run(&sparse_repo, SyncMode::Preemptive { force: true }, app)
-        .context("Running preemptive sync")?;
+    let request = SyncRequest::new(sparse_repo, SyncMode::Preemptive { force: true });
+    super::sync::run(&request, app).context("Running preemptive sync")?;
     Ok(ExitCode(0))
 }

--- a/focus/operations/src/clone.rs
+++ b/focus/operations/src/clone.rs
@@ -29,7 +29,7 @@ use tracing::{debug, error, info, info_span, warn};
 use url::Url;
 
 pub fn run_clone(mut clone_builder: CloneBuilder, app: Arc<App>) -> Result<()> {
-    (&mut clone_builder).add_clone_args(vec!["--progress"]);
+    clone_builder.add_clone_args(vec!["--progress"]);
     let (mut cmd, scmd) = clone_builder.build(app)?;
 
     scmd.ensure_success_or_log(&mut cmd, SandboxCommandOutput::Stderr)
@@ -487,7 +487,7 @@ fn clone_local(
     }
 
     let dense_repo = Repository::open(&dense_repo_path).context("Opening dense repo")?;
-    let sparse_repo = Repository::open(&sparse_repo_path).context("Opening sparse repo")?;
+    let sparse_repo = Repository::open(sparse_repo_path).context("Opening sparse repo")?;
 
     if copy_branches {
         let span = info_span!("Copying branches");
@@ -868,7 +868,7 @@ fn set_up_hooks(sparse_repo: &Path) -> Result<()> {
 fn fetch_default_remote(sparse_repo: &Path, app: Arc<App>) -> Result<()> {
     let (mut cmd, scmd) = git_helper::git_command(app)?;
     let _ = scmd.ensure_success_or_log(
-        cmd.current_dir(&sparse_repo).arg("fetch").arg("origin"),
+        cmd.current_dir(sparse_repo).arg("fetch").arg("origin"),
         SandboxCommandOutput::Stderr,
     )?;
 
@@ -1280,7 +1280,7 @@ mod twttr_test {
                 .map(|m| {
                     m.unwrap()
                         .path()
-                        .strip_prefix(&outlining_tree_path)
+                        .strip_prefix(outlining_tree_path)
                         .unwrap()
                         .to_owned()
                 })
@@ -1308,7 +1308,7 @@ mod twttr_test {
                 .map(|m| {
                     m.unwrap()
                         .path()
-                        .strip_prefix(&working_tree_path)
+                        .strip_prefix(working_tree_path)
                         .unwrap()
                         .to_owned()
                 })

--- a/focus/operations/src/clone.rs
+++ b/focus/operations/src/clone.rs
@@ -595,8 +595,15 @@ fn set_up_sparse_repo(
     } else {
         Some(RocksDBCache::new(repo.underlying()))
     };
-    repo.sync(head_commit.id(), &target_set, false, app, odb.as_ref())
-        .context("Sync failed")?;
+    repo.sync(
+        head_commit.id(),
+        &target_set,
+        false,
+        app,
+        odb.as_ref(),
+        None,
+    )
+    .context("Sync failed")?;
 
     repo.working_tree().unwrap().write_sync_point_ref()?;
 

--- a/focus/operations/src/clone.rs
+++ b/focus/operations/src/clone.rs
@@ -358,6 +358,7 @@ pub fn run(
     let configure_repo_then_move_in_place = || -> Result<()> {
         let template = match origin {
             Origin::Local(dense_repo_path) => {
+                tracing::info!(path = ?dense_repo_path, "Cloning from local path");
                 clone_local(
                     &dense_repo_path,
                     &tmp_sparse_repo_path,
@@ -370,6 +371,7 @@ pub fn run(
                 template
             }
             Origin::Remote(url) => {
+                tracing::info!(?url, "Cloning from remote");
                 clone_remote(
                     url.clone(),
                     &tmp_sparse_repo_path,

--- a/focus/operations/src/detect_build_graph_changes.rs
+++ b/focus/operations/src/detect_build_graph_changes.rs
@@ -37,7 +37,7 @@ fn find_committed_changes(app: Arc<App>, repo_path: &Path) -> Result<Vec<PathBuf
 
     let revspec = format!("{}..HEAD", &sync_state_oid);
     let output =
-        git_helper::run_consuming_stdout(repo_path, &["diff", "--name-only", &revspec], app)?;
+        git_helper::run_consuming_stdout(repo_path, ["diff", "--name-only", &revspec], app)?;
     let mut build_involved_changed_paths = Vec::<PathBuf>::new();
     for line in output.lines() {
         let parsed = PathBuf::from(line);
@@ -51,7 +51,7 @@ fn find_committed_changes(app: Arc<App>, repo_path: &Path) -> Result<Vec<PathBuf
 
 fn find_uncommitted_changes(app: Arc<App>, repo: &Path) -> Result<Vec<PathBuf>> {
     let output =
-        git_helper::run_consuming_stdout(repo, &["status", "--porcelain", "--no-renames"], app)?;
+        git_helper::run_consuming_stdout(repo, ["status", "--porcelain", "--no-renames"], app)?;
     let mut build_involved_changed_paths = Vec::<PathBuf>::new();
     for line in output.lines() {
         let mut tokens = line.split_ascii_whitespace().take(2);

--- a/focus/operations/src/event.rs
+++ b/focus/operations/src/event.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::{fs::File, path::Path, sync::Arc};
 use tracing::debug;
 
-use crate::sync::SyncMode;
+use crate::sync::{SyncMode, SyncRequest};
 
 /// Initializes hooks in passed in repo
 pub fn init(repo_path: &Path) -> Result<()> {
@@ -45,7 +45,7 @@ fn write_hooks_to_dir(hooks: &[&str], dir: &Path) -> Result<()> {
 pub fn post_merge(app: Arc<App>) -> Result<ExitCode> {
     let current_dir = std::env::current_dir().context("Failed to obtain current directory")?;
     debug!(sparse_repo = ?current_dir.display(), "Running post-merge hook");
-    crate::sync::run(&current_dir, SyncMode::Incremental, app)?;
+    let _response = crate::sync::run(&SyncRequest::new(&current_dir, SyncMode::Incremental), app)?;
     Ok(ExitCode(0))
 }
 

--- a/focus/operations/src/filter.rs
+++ b/focus/operations/src/filter.rs
@@ -7,6 +7,8 @@ use focus_util::app::{App, ExitCode};
 use std::{path::Path, sync::Arc};
 use tracing::info;
 
+use crate::sync::SyncRequest;
+
 pub fn run(
     sparse_repo: impl AsRef<Path>,
     app: Arc<App>,
@@ -40,8 +42,7 @@ pub fn run(
         repo.working_tree().unwrap().switch_filter_on(app.clone())?;
         if run_sync {
             crate::sync::run(
-                sparse_repo.as_ref(),
-                crate::sync::SyncMode::Incremental,
+                &SyncRequest::new(sparse_repo.as_ref(), crate::sync::SyncMode::Incremental),
                 app,
             )?;
         }

--- a/focus/operations/src/index.rs
+++ b/focus/operations/src/index.rs
@@ -101,6 +101,7 @@ fn resolve_targets(
                 true,
                 app.clone(),
                 Some(borrowed_odb),
+                None,
             )?;
             println!("Pattern count: {}", pattern_count);
 

--- a/focus/operations/src/maintenance/mod.rs
+++ b/focus/operations/src/maintenance/mod.rs
@@ -485,7 +485,7 @@ pub fn run(
     tracker: &Tracker,
     app: Arc<App>,
 ) -> Result<()> {
-    Runner::new(cli, tracker, app.clone())?.run(time_period, app.clone())?;
+    Runner::new(cli, tracker, app.clone())?.run(time_period, app)?;
     Ok(())
 }
 

--- a/focus/operations/src/maintenance/mod.rs
+++ b/focus/operations/src/maintenance/mod.rs
@@ -25,6 +25,8 @@ use maplit::hashmap;
 use strum_macros;
 use tracing::{debug, error, info, warn};
 
+use crate::sync::SyncRequest;
+
 pub use self::launchd::{schedule_disable, schedule_enable, Launchctl, ScheduleOpts};
 
 pub(crate) const DEFAULT_FOCUS_PATH: &str = "/opt/twitter_mde/bin/focus";
@@ -274,8 +276,10 @@ impl Runner<'_> {
         repo_path: &Path,
     ) -> Result<crate::sync::SyncStatus> {
         let sync_result = crate::sync::run(
-            repo_path,
-            crate::sync::SyncMode::Preemptive { force: false },
+            &SyncRequest::new(
+                repo_path,
+                crate::sync::SyncMode::Preemptive { force: false },
+            ),
             self.app.clone(),
         )
         .with_context(|| format!("Preemptively syncing in {}", repo_path.display()))?;

--- a/focus/operations/src/maintenance/mod.rs
+++ b/focus/operations/src/maintenance/mod.rs
@@ -291,7 +291,7 @@ impl Runner<'_> {
 
     #[tracing::instrument]
     fn run_maint(&self, time_period: TimePeriod, repo_path: &Path) -> Result<MaintResult> {
-        let _lock = match locking::hold_lock(repo_path, Path::new("maint.lock")) {
+        let _lock = match locking::hold_lock(repo_path, Path::new("maint.lock"), self.app.clone()) {
             Ok(lock) => lock,
             Err(e) => {
                 error!(?e, "failed to acquire lock");
@@ -427,7 +427,7 @@ impl Runner<'_> {
     }
 
     #[tracing::instrument]
-    pub fn run(&mut self, time_period: TimePeriod) -> Result<()> {
+    pub fn run(&mut self, time_period: TimePeriod, app: Arc<App>) -> Result<()> {
         if self.tracked_repos {
             self.run_tracked_repo_repair()?;
         }
@@ -485,7 +485,7 @@ pub fn run(
     tracker: &Tracker,
     app: Arc<App>,
 ) -> Result<()> {
-    Runner::new(cli, tracker, app)?.run(time_period)?;
+    Runner::new(cli, tracker, app.clone())?.run(time_period, app.clone())?;
     Ok(())
 }
 

--- a/focus/operations/src/maintenance/mod.rs
+++ b/focus/operations/src/maintenance/mod.rs
@@ -584,7 +584,7 @@ mod tests {
 
     fn assert_repo_defaults_set(config: &git2::Config) {
         for (k, v) in CONFIG_DEFAULTS.iter() {
-            let val = config.get_string(*k).unwrap();
+            let val = config.get_string(k).unwrap();
             assert_eq!(
                 val, *v,
                 "values for key {} were not equal: {} != {}",

--- a/focus/operations/src/pull.rs
+++ b/focus/operations/src/pull.rs
@@ -151,14 +151,14 @@ pub(crate) mod testing {
         // Create `refs/focus/sync`
         let _ = git_helper::run_consuming_stdout(
             repo_dir,
-            &["update-ref", "refs/focus/sync", &head],
+            ["update-ref", "refs/focus/sync", &head],
             app.clone(),
         )?;
 
         // Create a default prefetch ref
         let _ = git_helper::run_consuming_stdout(
             repo_dir,
-            &["update-ref", "refs/prefetch/remotes/origin/master", &head],
+            ["update-ref", "refs/prefetch/remotes/origin/master", &head],
             app.clone(),
         )?;
 
@@ -168,7 +168,7 @@ pub(crate) mod testing {
         // Create a default remote ref
         let _ = git_helper::run_consuming_stdout(
             repo_dir,
-            &["update-ref", "refs/remotes/origin/master", &head],
+            ["update-ref", "refs/remotes/origin/master", &head],
             app.clone(),
         )?;
 
@@ -185,7 +185,7 @@ pub(crate) mod testing {
         // Update prefetch default to new commit
         let _ = git_helper::run_consuming_stdout(
             repo_dir,
-            &[
+            [
                 "update-ref",
                 "refs/prefetch/remotes/origin/master",
                 &new_commit,
@@ -194,7 +194,7 @@ pub(crate) mod testing {
         )?;
 
         // Switch back to `main` branch
-        let _ = git_helper::run_consuming_stdout(repo_dir, &["checkout", "main"], app.clone())?;
+        let _ = git_helper::run_consuming_stdout(repo_dir, ["checkout", "main"], app.clone())?;
 
         // Since focus/sync still points to `main` HEAD, merge base validation should still fail
         assert!(validate_merge_base(app.clone(), repo_dir).is_err());
@@ -202,7 +202,7 @@ pub(crate) mod testing {
         // Update focus/sync to new commit
         let _ = git_helper::run_consuming_stdout(
             repo_dir,
-            &["update-ref", "refs/focus/sync", &new_commit],
+            ["update-ref", "refs/focus/sync", &new_commit],
             app.clone(),
         )?;
 

--- a/focus/operations/src/selection.rs
+++ b/focus/operations/src/selection.rs
@@ -29,7 +29,7 @@ use focus_internals::{
     target::Target,
 };
 
-use crate::sync::SyncMode;
+use crate::sync::{SyncMode, SyncRequest};
 
 pub fn save(
     sparse_repo: impl AsRef<Path>,
@@ -168,8 +168,11 @@ fn mutate(
         if sync_if_changed {
             info!("Synchronizing after selection changed");
             // TODO: Use the correct sync mode here. Sync will override for SyncMode::Incremental, but that feels janky.
-            let result = super::sync::run(sparse_repo.as_ref(), SyncMode::Incremental, app)
-                .context("Synchronizing changes")?;
+            let result = super::sync::run(
+                &SyncRequest::new(sparse_repo.as_ref(), SyncMode::Incremental),
+                app,
+            )
+            .context("Synchronizing changes")?;
             synced = result.status == super::sync::SyncStatus::Success;
             backup.unwrap().discard();
         }

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -147,8 +147,8 @@ pub struct SyncResult {
 
 /// Synchronize the sparse repo's contents with the build graph. Returns a SyncResult indicating what happened.
 pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
-    let repo = Repo::open(request.sparse_repo_path(), app.clone())
-        .context("Failed to open the repo")?;
+    let repo =
+        Repo::open(request.sparse_repo_path(), app.clone()).context("Failed to open the repo")?;
 
     if !repo.working_tree().unwrap().get_filter_config()? {
         info!("Sync does not run when focus filter is off. Run \"focus filter on\" to turn filter back on.");
@@ -232,9 +232,6 @@ pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
     let backed_up_sparse_profile: Option<BackedUpFile> = if preemptive {
         None
     } else {
-        super::ensure_clean::run(request.sparse_repo_path(), app.clone())
-            .context("Failed trying to determine whether working trees were clean")?;
-
         ti_client
             .get_context()
             .add_to_custom_map("total_target_count", targets.len().to_string());

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -224,11 +224,8 @@ pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
                 request.sparse_repo_path().display()
             )
         })?;
-    let _snapshot_guard = git::snapshot::ReapplyGuard::new(
-        request.sparse_repo_path(),
-        snapshot.clone(),
-        app.clone(),
-    );
+    let _snapshot_guard =
+        git::snapshot::ReapplyGuard::new(request.sparse_repo_path(), snapshot.clone(), app.clone());
 
     let selections = repo.selection_manager()?;
     let selection = selections.computed_selection()?;

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -204,8 +204,12 @@ pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
         }
     }
 
-    let _lock = locking::hold_lock(request.sparse_repo_path(), Path::new("sync.lock"))
-        .context("Failed to obtain synchronization lock")?;
+    let _lock = locking::hold_lock(
+        request.sparse_repo_path(),
+        Path::new("sync.lock"),
+        app.clone(),
+    )
+    .context("Failed to obtain synchronization lock")?;
 
     let sparse_profile_path = repo.git_dir().join("info").join("sparse-checkout");
     if !sparse_profile_path.is_file() {

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -225,7 +225,7 @@ pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
             )
         })?;
     let _snapshot_guard = git::snapshot::ReapplyGuard::new(
-        request.sparse_repo_path().to_owned(),
+        request.sparse_repo_path(),
         snapshot.clone(),
         app.clone(),
     );

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -122,7 +122,7 @@ impl SyncRequest {
     }
 
     pub fn sparse_repo_path(&self) -> &Path {
-        &self.sparse_repo.as_path()
+        self.sparse_repo.as_path()
     }
 
     pub fn mode(&self) -> SyncMode {
@@ -147,7 +147,7 @@ pub struct SyncResult {
 
 /// Synchronize the sparse repo's contents with the build graph. Returns a SyncResult indicating what happened.
 pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
-    let repo = Repo::open(request.sparse_repo_path().as_ref(), app.clone())
+    let repo = Repo::open(request.sparse_repo_path(), app.clone())
         .context("Failed to open the repo")?;
 
     if !repo.working_tree().unwrap().get_filter_config()? {
@@ -203,7 +203,7 @@ pub fn run(request: &SyncRequest, app: Arc<App>) -> Result<SyncResult> {
         }
     }
 
-    let _lock = locking::hold_lock(request.sparse_repo_path().as_ref(), Path::new("sync.lock"))
+    let _lock = locking::hold_lock(request.sparse_repo_path(), Path::new("sync.lock"))
         .context("Failed to obtain synchronization lock")?;
 
     let sparse_profile_path = repo.git_dir().join("info").join("sparse-checkout");

--- a/focus/operations/src/sync.rs
+++ b/focus/operations/src/sync.rs
@@ -86,7 +86,7 @@ pub enum SyncStatus {
 #[derive(Debug, PartialEq, Eq)]
 pub enum SyncMechanism {
     /// The sync was performed via outlining, incorporating data from the content addressed cache where possible.
-    CachedOutline,
+    IncrementalOutline,
 
     /// The sync was performed via outlining in one shot, without using the content addressed cache.
     OneShotOutline,
@@ -98,7 +98,7 @@ pub enum SyncMechanism {
 impl fmt::Display for SyncMechanism {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SyncMechanism::CachedOutline => write!(f, "outline"),
+            SyncMechanism::IncrementalOutline => write!(f, "outline"),
             SyncMechanism::OneShotOutline => write!(f, "one-shot-outline"),
             SyncMechanism::ProjectCache => write!(f, "project-cache"),
         }
@@ -130,7 +130,7 @@ pub fn run(sparse_repo: &Path, mode: SyncMode, app: Arc<App>) -> Result<SyncResu
             checked_out: false,
             commit_id: None,
             status: SyncStatus::SkippedUnfilterView,
-            mechanism: SyncMechanism::CachedOutline,
+            mechanism: SyncMechanism::IncrementalOutline,
         });
     }
 
@@ -145,7 +145,7 @@ pub fn run(sparse_repo: &Path, mode: SyncMode, app: Arc<App>) -> Result<SyncResu
                 checked_out: false,
                 commit_id: None,
                 status: SyncStatus::SkippedPreemptiveSyncDisabled,
-                mechanism: SyncMechanism::CachedOutline,
+                mechanism: SyncMechanism::IncrementalOutline,
             });
         }
 
@@ -172,7 +172,7 @@ pub fn run(sparse_repo: &Path, mode: SyncMode, app: Arc<App>) -> Result<SyncResu
                 checked_out: false,
                 commit_id: None,
                 status: SyncStatus::SkippedPreemptiveSyncCancelledByActivity,
-                mechanism: SyncMechanism::CachedOutline,
+                mechanism: SyncMechanism::IncrementalOutline,
             });
         }
     }
@@ -189,7 +189,7 @@ pub fn run(sparse_repo: &Path, mode: SyncMode, app: Arc<App>) -> Result<SyncResu
     let selection = selections.computed_selection()?;
     let targets = selections.compute_complete_target_set()?;
 
-    let mut mechanism = SyncMechanism::CachedOutline;
+    let mut mechanism = SyncMechanism::IncrementalOutline;
 
     // Add target/project to TI data.
     let app_for_ti_client = app.clone();

--- a/focus/operations/src/testing/integration.rs
+++ b/focus/operations/src/testing/integration.rs
@@ -313,7 +313,7 @@ pub fn configure_ci_for_dense_repo(fixture: &RepoPairFixture) -> Result<()> {
 #[cfg(test)]
 mod twttr_test {
     use super::RepoPairFixture;
-    use anyhow::{Result};
+    use anyhow::Result;
     use focus_testing::init_logging;
 
     #[test]

--- a/focus/operations/src/testing/integration.rs
+++ b/focus/operations/src/testing/integration.rs
@@ -22,7 +22,10 @@ use focus_util::app::App;
 
 use focus_internals::{model::repo::Repo, tracker::Tracker};
 
-use crate::{clone::CloneArgs, sync::SyncMode};
+use crate::{
+    clone::CloneArgs,
+    sync::{SyncMode, SyncRequest},
+};
 
 pub use focus_testing::GitBinary;
 
@@ -129,8 +132,7 @@ impl RepoPairFixture {
     pub fn perform_sync(&self) -> Result<bool> {
         self.ensure_sync_mode()?;
         crate::sync::run(
-            &self.sparse_repo_path,
-            self.sync_mode.get(),
+            &SyncRequest::new(&self.sparse_repo_path, self.sync_mode.get()),
             self.app.clone(),
         )
         .map(|result| result.checked_out)

--- a/focus/operations/src/testing/integration.rs
+++ b/focus/operations/src/testing/integration.rs
@@ -311,13 +311,14 @@ pub fn configure_ci_for_dense_repo(fixture: &RepoPairFixture) -> Result<()> {
 #[cfg(test)]
 mod twttr_test {
     use super::RepoPairFixture;
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use focus_testing::init_logging;
 
     #[test]
     fn test_ci_config_is_set_in_dense_repo() -> Result<()> {
         init_logging();
         let fixture = RepoPairFixture::new()?;
+        super::configure_ci_for_dense_repo(&fixture)?;
 
         let repo = fixture.dense_repo.repo()?;
 

--- a/focus/operations/src/testing/integration.rs
+++ b/focus/operations/src/testing/integration.rs
@@ -313,7 +313,7 @@ pub fn configure_ci_for_dense_repo(fixture: &RepoPairFixture) -> Result<()> {
 #[cfg(test)]
 mod twttr_test {
     use super::RepoPairFixture;
-    use anyhow::{Context, Result};
+    use anyhow::{Result};
     use focus_testing::init_logging;
 
     #[test]

--- a/focus/operations/src/testing/integration.rs
+++ b/focus/operations/src/testing/integration.rs
@@ -171,7 +171,7 @@ impl RepoPairFixture {
             .command()
             .arg("fetch")
             .arg(remote_name)
-            .current_dir(&path)
+            .current_dir(path)
             .assert()
             .success();
         let fetch_head_path = path.join(".git").join("FETCH_HEAD");
@@ -195,7 +195,7 @@ impl RepoPairFixture {
             .arg("pull")
             .arg(remote_name)
             .arg(branch)
-            .current_dir(&path)
+            .current_dir(path)
             .assert()
             .success();
 

--- a/focus/operations/src/testing/sync.rs
+++ b/focus/operations/src/testing/sync.rs
@@ -73,7 +73,7 @@ fn add_updated_content(scratch_repo: &ScratchGitRepo) -> Result<git2::Oid> {
 #[test]
 fn sync_upstream_changes_with_incremental_sync() -> Result<()> {
     let used_sync_mode = sync_upstream_changes_internal(SyncMode::Incremental)?;
-    assert_eq!(used_sync_mode, SyncMechanism::CachedOutline);
+    assert_eq!(used_sync_mode, SyncMechanism::IncrementalOutline);
     Ok(())
 }
 
@@ -405,7 +405,7 @@ fn clone_contains_top_level_internal(sync_mode: SyncMode) -> Result<()> {
 fn sync_skips_checkout_with_unchanged_profile_with_incremental_sync() -> Result<()> {
     let sync_mechanism_used =
         sync_skips_checkout_with_unchanged_profile_internal(SyncMode::Incremental)?;
-    assert_eq!(sync_mechanism_used, SyncMechanism::CachedOutline);
+    assert_eq!(sync_mechanism_used, SyncMechanism::IncrementalOutline);
     Ok(())
 }
 

--- a/focus/operations/src/testing/sync.rs
+++ b/focus/operations/src/testing/sync.rs
@@ -572,8 +572,8 @@ fn sync_configures_working_and_outlining_trees() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "ci"))]
 #[test]
+#[cfg(not(feature = "ci"))]
 fn regression_adding_directory_targets_present_in_mandatory_sets() -> Result<()> {
     init_logging();
 

--- a/focus/operations/src/testing/sync_with_project_cache.rs
+++ b/focus/operations/src/testing/sync_with_project_cache.rs
@@ -8,7 +8,7 @@ use focus_util::{app::ExitCode, git_helper};
 
 use crate::{
     project_cache,
-    sync::{SyncMechanism, SYNC_FROM_PROJECT_CACHE_REQUIRED_ERROR_MESSAGE},
+    sync::{SyncMechanism, SyncRequest, SYNC_FROM_PROJECT_CACHE_REQUIRED_ERROR_MESSAGE},
     testing::integration::RepoPairFixture,
 };
 
@@ -99,8 +99,10 @@ fn project_cache_falls_back_with_non_project_targets_selected() -> Result<()> {
 
     // Verify that syncing with the project cache fails
     match crate::sync::run(
-        &fixture.underlying.sparse_repo_path,
-        crate::sync::SyncMode::RequireProjectCache,
+        &SyncRequest::new(
+            &fixture.underlying.sparse_repo_path,
+            crate::sync::SyncMode::RequireProjectCache,
+        ),
         app,
     ) {
         Err(e) => {
@@ -133,8 +135,10 @@ fn project_cache_answers_with_only_projects_selected() -> Result<()> {
 
     // Verify that syncing with the project cache fails
     let result = crate::sync::run(
-        &fixture.underlying.sparse_repo_path,
-        crate::sync::SyncMode::RequireProjectCache,
+        &SyncRequest::new(
+            &fixture.underlying.sparse_repo_path,
+            crate::sync::SyncMode::RequireProjectCache,
+        ),
         app,
     )?;
     assert_eq!(result.mechanism, SyncMechanism::ProjectCache);
@@ -170,8 +174,10 @@ fn project_cache_generates_all_projects() -> Result<()> {
     )?;
 
     let result = crate::sync::run(
-        &fixture.underlying.sparse_repo_path,
-        crate::sync::SyncMode::RequireProjectCache,
+        &SyncRequest::new(
+            &fixture.underlying.sparse_repo_path,
+            crate::sync::SyncMode::RequireProjectCache,
+        ),
         app,
     )?;
     assert_eq!(result.mechanism, SyncMechanism::ProjectCache);

--- a/focus/testing/src/scratch_git_repo.rs
+++ b/focus/testing/src/scratch_git_repo.rs
@@ -270,6 +270,25 @@ impl ScratchGitRepo {
         Ok(())
     }
 
+    pub fn remove_file(&self, relative_filename: impl AsRef<Path>) -> Result<()> {
+        if !self
+            .git_binary
+            .command()
+            .arg("rm")
+            .arg("--")
+            .arg(relative_filename.as_ref())
+            .current_dir(&self.path)
+            .spawn()
+            .context("running `git rm`")?
+            .wait()
+            .context("`git rm` failed")?
+            .success()
+        {
+            bail!("`git rm` exited abnormally");
+        }
+        Ok(())
+    }
+
     pub fn commit_all(&self, message: impl AsRef<str>) -> Result<git2::Oid> {
         // Run `git commit`
         if !self

--- a/focus/testing/src/scratch_git_repo.rs
+++ b/focus/testing/src/scratch_git_repo.rs
@@ -105,6 +105,27 @@ impl ScratchGitRepo {
         })
     }
 
+    pub fn add_worktree(&self, destination_path: &Path) -> Result<()> {
+        tracing::info!(current = ?self.path(), destination = ?destination_path, "Adding worktree");
+        let exit_status = self
+            .git_binary
+            .command()
+            .current_dir(self.path())
+            .arg("worktree")
+            .arg("add")
+            .arg("-d")
+            .arg(destination_path)
+            .status()?;
+        if !exit_status.success() {
+            bail!(
+                "Failed to create a detached worktree in {}",
+                destination_path.display()
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn make_clone(&self) -> Result<Self> {
         Self::new_local_clone(self.path())
     }

--- a/focus/testing/src/scratch_git_repo.rs
+++ b/focus/testing/src/scratch_git_repo.rs
@@ -86,7 +86,7 @@ impl ScratchGitRepo {
             .arg("add")
             .arg("--")
             .arg(".")
-            .current_dir(&destination_path)
+            .current_dir(destination_path)
             .assert()
             .success();
 
@@ -95,7 +95,7 @@ impl ScratchGitRepo {
             .arg("commit")
             .arg("-m")
             .arg("Initial import")
-            .current_dir(&destination_path)
+            .current_dir(destination_path)
             .assert()
             .success();
 
@@ -227,7 +227,7 @@ impl ScratchGitRepo {
         qualified_origin.push(origin.as_os_str());
         git_binary
             .command()
-            .args(&[
+            .args([
                 OsStr::new("clone"),
                 &qualified_origin,
                 destination.as_os_str(),

--- a/focus/tracing/src/git_trace2.rs
+++ b/focus/tracing/src/git_trace2.rs
@@ -235,7 +235,7 @@ impl Events {
 
         let mut result: Vec<Event> = Vec::new();
 
-        let bytes = std::fs::read(&path)?;
+        let bytes = std::fs::read(path)?;
         debug!("parsing: {:?}", &path);
         for line in BufReader::new(bytes.as_slice()).lines() {
             let s = line?;
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     fn test_parse_examples() -> Result<()> {
         for (k, v) in data::DATA.iter() {
-            let xyz: serde_json::Result<Event> = serde_json::from_str(*v);
+            let xyz: serde_json::Result<Event> = serde_json::from_str(v);
             if let Err(e) = xyz {
                 println!("failure: {}, {:?}", *k, e);
                 bail!(e)

--- a/focus/util/Cargo.toml
+++ b/focus/util/Cargo.toml
@@ -22,6 +22,7 @@ regex = "1.5.5"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
+sha2 = "0.10.2"
 tar = { version = "0.4.38", features = ["xattr"] }
 tempfile = "3.2.0"
 termion = "1.5.6"

--- a/focus/util/Cargo.toml
+++ b/focus/util/Cargo.toml
@@ -14,6 +14,7 @@ git2 = { version = "0.15", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }
+hex = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4.0"
 nix = "0.23.0"
 once_cell = "1.4.0"
@@ -21,6 +22,7 @@ regex = "1.5.5"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
+tar = { version = "0.4.38", features = ["xattr"] }
 tempfile = "3.2.0"
 termion = "1.5.6"
 tool-insights-client = { path = "../../tool_insights_client", optional = true }

--- a/focus/util/src/backed_up_file.rs
+++ b/focus/util/src/backed_up_file.rs
@@ -25,7 +25,7 @@ impl BackedUpFile {
         name.push(".backup");
         backup_path.set_file_name(name);
 
-        std::fs::copy(&path, &backup_path).with_context(|| {
+        std::fs::copy(path, &backup_path).with_context(|| {
             format!(
                 "Copying {} to the backup file {}",
                 &path.display(),

--- a/focus/util/src/files.rs
+++ b/focus/util/src/files.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use std::{fs::File, io::Read, path::Path};
 

--- a/focus/util/src/files.rs
+++ b/focus/util/src/files.rs
@@ -1,0 +1,25 @@
+use anyhow::{Context, Result};
+use std::{fs::File, io::Read, path::Path};
+
+use sha2::{Digest, Sha256};
+
+const BUFFER_SIZE: usize = 4096;
+
+// Hash a file using SHA-256
+pub fn hash(path: impl AsRef<Path>) -> Result<Vec<u8>> {
+    let path = path.as_ref();
+    let mut hasher = Sha256::new();
+    let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+    let mut file = File::open(path)
+        .context("Hashing file")
+        .with_context(|| format!("Opening {} failed", path.display()))?;
+    loop {
+        let read_bytes = file.read(&mut buffer[..]).context("Read failed")?;
+        if read_bytes == 0 {
+            break;
+        }
+        hasher.update(&buffer[0..read_bytes]);
+    }
+
+    Ok(hasher.finalize().to_vec())
+}

--- a/focus/util/src/git/mod.rs
+++ b/focus/util/src/git/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod model;
+pub mod snapshot;
+pub mod working_tree;

--- a/focus/util/src/git/model.rs
+++ b/focus/util/src/git/model.rs
@@ -1,0 +1,415 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Kind of working tree state entity
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Kind {
+    Header,
+    Ordinary,
+    RenameOrCopy,
+    Unmerged,
+    Untracked,
+    Ignored,
+}
+
+/// Whether the working tree state is regular or unmerged. This is used in interpreting combined dispositions.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum State {
+    Regular,
+    Unmerged,
+}
+
+/// Represents the possible values of the 'X' and 'Y' columns from `git-status` output.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Disposition {
+    Unmodified,         /* '.' = unmodified (besides v1 = ' ') */
+    Modified,           /* M = modified */
+    FileTypeChanged,    /* T = file type changed (regular file, symbolic link or submodule) */
+    Added,              /* A = added */
+    Deleted,            /* D = deleted */
+    Renamed,            /* R = renamed */
+    Copied,             /* C = copied (if config option status.renames is set to "copies") */
+    UpdatedButUnmerged, /* U = updated but unmerged */
+    Untracked,          /* ? = untracked */
+    Ignored,            /* ! = ignored */
+}
+
+impl TryFrom<char> for Disposition {
+    type Error = anyhow::Error;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            '.' => Ok(Disposition::Unmodified),
+            'M' => Ok(Disposition::Modified),
+            'T' => Ok(Disposition::FileTypeChanged),
+            'A' => Ok(Disposition::Added),
+            'D' => Ok(Disposition::Deleted),
+            'R' => Ok(Disposition::Renamed),
+            'C' => Ok(Disposition::Copied),
+            'U' => Ok(Disposition::UpdatedButUnmerged),
+            '?' => Ok(Disposition::Untracked),
+            '!' => Ok(Disposition::Ignored),
+            _ => Err(anyhow::anyhow!(
+                "Unexpected disposition character '{}'",
+                value
+            )),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum DispositionInterpretation {
+    // Normal state
+    NotUpdated,
+    UpdatedInIndex,
+    TypeChangedInIndex,
+    AddedToIndex,
+    DeletedFromIndex,
+    RenamedInIndex,
+    CopiedInIndex,
+    // IndexAndWorkingTreeMatches, // Disabled for now because it is unreachable below.
+    WorkTreeChangedSinceIndex,
+    TypeChangedInWorkTreeSinceIndex,
+    DeletedInWorkTree,
+    RenamedInWorkTree,
+    CopiedInWorkTree,
+
+    // Unmerged state
+    UnmergedBothDeleted,
+    UnmergedAddedByUs,
+    UnmergedDeletedByThem,
+    UnmergedAddedByThem,
+    UnmergedDeletedByUs,
+    UnmergedBothAdded,
+    UnmergedBothModified,
+
+    // Specials
+    Untracked,
+    Ignored,
+}
+
+#[cfg(test)]
+fn assert_disposition_interpretation(
+    x_values: Vec<Disposition>,
+    y_values: Vec<Disposition>,
+    expected: DispositionInterpretation,
+) {
+    for x in x_values.iter() {
+        for y in y_values.iter() {
+            assert_eq!(
+                DispositionInterpretation::try_from((State::Regular, *x, *y)).unwrap(),
+                expected,
+                "\n state: {:?},\n     x: {:?},\n     y: {:?}",
+                State::Regular,
+                *x,
+                *y
+            );
+        }
+    }
+}
+
+#[test]
+fn test_regular_disposition_interpretations_not_updated() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    //          [AMD]   not updated
+    assert_disposition_interpretation(
+        vec![Disposition::Unmodified],
+        vec![
+            Disposition::Added,
+            Disposition::Modified,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::NotUpdated,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_updated_in_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // M        [ MTD]  updated in index
+    assert_disposition_interpretation(
+        vec![Disposition::Modified],
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::UpdatedInIndex,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_type_changed_in_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // A        [ MTD]  added to index
+    assert_disposition_interpretation(
+        vec![Disposition::FileTypeChanged],
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::TypeChangedInIndex,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_added_to_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // A        [ MTD]  added to index
+    assert_disposition_interpretation(
+        vec![Disposition::Added],
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::AddedToIndex,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_deleted_from_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // D                deleted from index
+    assert_disposition_interpretation(
+        vec![Disposition::Deleted],
+        vec![Disposition::Unmodified],
+        DispositionInterpretation::DeletedFromIndex,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_renamed_in_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // R        [ MTD]  renamed in index
+    assert_disposition_interpretation(
+        vec![Disposition::Renamed],
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::RenamedInIndex,
+    );
+}
+
+#[test]
+fn test_regular_disposition_interpretations_copied_in_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // C        [ MTD]  copied in index
+    assert_disposition_interpretation(
+        vec![Disposition::Copied],
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Deleted,
+        ],
+        DispositionInterpretation::CopiedInIndex,
+    );
+}
+
+#[ignore]
+#[test]
+fn test_regular_disposition_interpretations_work_tree_changed_since_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // [ MTARC]    M    work tree changed since index
+    assert_disposition_interpretation(
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Added,
+            Disposition::Renamed,
+            Disposition::Copied,
+        ],
+        vec![Disposition::Modified],
+        DispositionInterpretation::WorkTreeChangedSinceIndex,
+    );
+}
+
+#[ignore]
+#[test]
+fn test_regular_disposition_interpretations_type_changed_in_work_tree_changed_since_index() {
+    // X          Y     Meaning
+    // -------------------------------------------------
+    // [ MTARC]    T    type changed in work tree since index
+    assert_disposition_interpretation(
+        vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Added,
+            Disposition::Renamed,
+            Disposition::Copied,
+        ],
+        vec![Disposition::FileTypeChanged],
+        DispositionInterpretation::TypeChangedInWorkTreeSinceIndex,
+    );
+}
+
+impl TryFrom<(State, Disposition, Disposition)> for DispositionInterpretation {
+    type Error = anyhow::Error;
+
+    /*
+    From manpage git-status(1) § "Short Format", see https://git-scm.com/docs/git-status
+
+    X          Y     Meaning
+    -------------------------------------------------
+            [AMD]   not updated
+    M        [ MTD]  updated in index
+    T        [ MTD]  type changed in index
+    A        [ MTD]  added to index
+    D                deleted from index
+    R        [ MTD]  renamed in index
+    C        [ MTD]  copied in index
+    [MTARC]          index and work tree matches
+    [ MTARC]    M    work tree changed since index
+    [ MTARC]    T    type changed in work tree since index
+    [ MTARC]    D    deleted in work tree
+                R    renamed in work tree
+                C    copied in work tree
+    -------------------------------------------------
+    D           D    unmerged, both deleted
+    A           U    unmerged, added by us
+    U           D    unmerged, deleted by them
+    U           A    unmerged, added by them
+    D           U    unmerged, deleted by us
+    A           A    unmerged, both added
+    U           U    unmerged, both modified
+    -------------------------------------------------
+    ?           ?    untracked
+    !           !    ignored
+    -------------------------------------------------
+    */
+    /// Interpret a tuple of repo state and a pair of dispositions according to the table defined in git-status(1) § "Short Format"
+    fn try_from(value: (State, Disposition, Disposition)) -> Result<Self, Self::Error> {
+        let (state, x, y) = value;
+        match (state, x, y) {
+            (
+                State::Regular,
+                Disposition::Unmodified,
+                Disposition::Added | Disposition::Modified | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::NotUpdated),
+            (
+                State::Regular,
+                Disposition::Modified,
+                Disposition::Unmodified
+                | Disposition::Modified
+                | Disposition::FileTypeChanged
+                | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::UpdatedInIndex),
+            (
+                State::Regular,
+                Disposition::FileTypeChanged,
+                Disposition::Unmodified
+                | Disposition::Modified
+                | Disposition::FileTypeChanged
+                | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::TypeChangedInIndex),
+            (
+                State::Regular,
+                Disposition::Added,
+                Disposition::Unmodified
+                | Disposition::Modified
+                | Disposition::FileTypeChanged
+                | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::AddedToIndex),
+            (State::Regular, Disposition::Deleted, _) => {
+                Ok(DispositionInterpretation::DeletedFromIndex)
+            }
+            (
+                State::Regular,
+                Disposition::Renamed,
+                Disposition::Unmodified
+                | Disposition::Modified
+                | Disposition::FileTypeChanged
+                | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::RenamedInIndex),
+            (
+                State::Regular,
+                Disposition::Copied,
+                Disposition::Unmodified
+                | Disposition::Modified
+                | Disposition::FileTypeChanged
+                | Disposition::Deleted,
+            ) => Ok(DispositionInterpretation::CopiedInIndex),
+            // (
+            //     State::Regular,
+            //     Disposition::Modified
+            //     | Disposition::FileTypeChanged
+            //     | Disposition::Added
+            //     | Disposition::Renamed
+            //     | Disposition::Copied,
+            //     Disposition::Unmodified,
+            // ) =>
+            // /* TODO: Figure out why this pattern is not matched */
+            // {
+            //     Ok(DispositionInterpretation::IndexAndWorkingTreeMatches)
+            // }
+            (State::Regular, _, Disposition::Modified) => {
+                Ok(DispositionInterpretation::WorkTreeChangedSinceIndex)
+            }
+            (State::Regular, _, Disposition::FileTypeChanged) => {
+                Ok(DispositionInterpretation::TypeChangedInWorkTreeSinceIndex)
+            }
+            (State::Regular, _, Disposition::Deleted) => {
+                Ok(DispositionInterpretation::DeletedInWorkTree)
+            }
+            (State::Regular, Disposition::Unmodified, Disposition::Renamed) => {
+                Ok(DispositionInterpretation::RenamedInWorkTree)
+            }
+            (State::Regular, Disposition::Unmodified, Disposition::Copied) => {
+                Ok(DispositionInterpretation::CopiedInWorkTree)
+            }
+            (State::Unmerged, Disposition::Deleted, Disposition::Deleted) => {
+                Ok(DispositionInterpretation::UnmergedBothDeleted)
+            }
+            (State::Unmerged, Disposition::Added, Disposition::UpdatedButUnmerged) => {
+                Ok(DispositionInterpretation::UnmergedAddedByUs)
+            }
+            (State::Unmerged, Disposition::UpdatedButUnmerged, Disposition::Deleted) => {
+                Ok(DispositionInterpretation::UnmergedDeletedByThem)
+            }
+            (State::Unmerged, Disposition::UpdatedButUnmerged, Disposition::Added) => {
+                Ok(DispositionInterpretation::UnmergedAddedByThem)
+            }
+            (State::Unmerged, Disposition::Deleted, Disposition::UpdatedButUnmerged) => {
+                Ok(DispositionInterpretation::UnmergedDeletedByUs)
+            }
+            (State::Unmerged, Disposition::Added, Disposition::Added) => {
+                Ok(DispositionInterpretation::UnmergedBothAdded)
+            }
+            (State::Unmerged, Disposition::UpdatedButUnmerged, Disposition::UpdatedButUnmerged) => {
+                Ok(DispositionInterpretation::UnmergedBothModified)
+            }
+
+            (_, Disposition::Untracked, Disposition::Untracked) => {
+                Ok(DispositionInterpretation::Untracked)
+            }
+            (_, Disposition::Ignored, Disposition::Ignored) => {
+                Ok(DispositionInterpretation::Ignored)
+            }
+
+            _ => Err(anyhow::anyhow!(
+                "Unsupported disposition combination (state={:?}, X='{:?}', Y='{:?}'",
+                &state,
+                x,
+                y
+            )),
+        }
+    }
+}

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -269,7 +269,7 @@ mod testing {
             assert!(!tracked_removed_path.is_file());
 
             // The working tree status should be the same.
-            let status = git::working_tree::status(repo.path(), app)?;
+            let status = git::working_tree::status(repo.path(), app.clone())?;
             assert_eq!(status, initial_status);
         }
 

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -42,8 +42,6 @@ lazy_static! {
 ///
 /// The archive should preserve ownership, modes, and extended attributes on the files.
 pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<CreationResult>> {
-    let app = app.clone();
-
     let repo_path = repo_path.as_ref();
     let git_dir = git_helper::git_dir(repo_path)?;
     let repo = Repository::open(repo_path)
@@ -117,7 +115,7 @@ pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<Creat
 
     // Clean up the working tree by cleaning untracked files.
     let _ = git_helper::run_consuming_stdout(repo_path, vec!["clean", "-f", "-d"], app.clone())?;
-    let _ = git_helper::run_consuming_stdout(repo_path, vec!["reset", "--hard"], app.clone())?;
+    let _ = git_helper::run_consuming_stdout(repo_path, vec!["reset", "--hard"], app)?;
 
     Ok(Some(CreationResult { path: archive_path }))
 }
@@ -170,11 +168,7 @@ pub fn apply(
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("Failed to convert patch path to a string"))?;
 
-    let _ = git_helper::run_consuming_stdout(
-        repo_path,
-        vec!["apply", "-v", patch_path_str],
-        app.clone(),
-    )?;
+    let _ = git_helper::run_consuming_stdout(repo_path, vec!["apply", "-v", patch_path_str], app)?;
 
     // Remove the patch file
     std::fs::remove_file(&patch_path)

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -24,7 +24,6 @@ use crate::{app::App, git_helper, lock_file::LockFile};
 
 use super::model::Disposition;
 
-pub struct CreationResult {
 pub struct SnapshotResult {
     pub path: PathBuf,
 }
@@ -229,7 +228,8 @@ mod testing {
         {
             let untracked_entries =
                 initial_status.find_entries_with_disposition(Disposition::Untracked)?;
-            let untracked_entry = untracked_entries.first()
+            let untracked_entry = untracked_entries
+                .first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(untracked_entry.path.as_path(), &untracked_file_name);
 

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -223,16 +223,14 @@ mod testing {
         {
             let untracked_entries =
                 initial_status.find_entries_with_disposition(Disposition::Untracked)?;
-            let untracked_entry = untracked_entries
-                .iter()
-                .next()
+            let untracked_entry = untracked_entries.first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(untracked_entry.path.as_path(), &untracked_file_name);
 
             let tracked_entries =
                 initial_status.find_entries_with_disposition(Disposition::Added)?;
             {
-                let tracked_entry = tracked_entries.iter().next().ok_or_else(|| {
+                let tracked_entry = tracked_entries.first().ok_or_else(|| {
                     anyhow::anyhow!("Expected an untracked entry and there was none")
                 })?;
                 assert_eq!(tracked_entry.path.as_path(), &tracked_filename);
@@ -265,7 +263,7 @@ mod testing {
             assert!(!tracked_removed_path.is_file());
 
             // The working tree status should be the same.
-            let status = git::working_tree::status(repo.path(), app.clone())?;
+            let status = git::working_tree::status(repo.path(), app)?;
             assert_eq!(status, initial_status);
         }
 

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -1,0 +1,280 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This is a fast snapshotting mechanism that does not depend on `git stash`.
+As of v2.38, `stash` requires full indices to work, so it is quite slow in
+our repositories. We should revisit using this once `git stash` is made
+fully sparse-index compatible.
+*/
+
+use anyhow::{bail, Context, Result};
+use git2::Repository;
+use lazy_static::lazy_static;
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+};
+use tar::{Archive, Builder};
+
+use crate::{app::App, git_helper, lock_file::LockFile};
+
+use super::model::Disposition;
+
+pub struct CreationResult {
+    pub path: PathBuf,
+}
+
+lazy_static! {
+    static ref TRACKED_CHANGE_PATCH_FILENAME: PathBuf = PathBuf::from("tracked-changes.patch");
+}
+/// When changes to the working tree are present, returns a snapshot containing the index and
+/// changed files from the work tree. This archive has a simple structure and is meant to
+/// replicate the working tree state by being extracted in the repo's top-level.
+///
+///
+/// .git/index                     # The index file.
+/// focus/tracked-changes.patch    # A patch of changes to tracked files.
+/// a/changed/path                 # Untracked changed files ...
+///
+/// The archive should preserve ownership, modes, and extended attributes on the files.
+pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<CreationResult>> {
+    let app = app.clone();
+
+    let repo_path = repo_path.as_ref();
+    let git_dir = git_helper::git_dir(repo_path)?;
+    let repo = Repository::open(repo_path)
+        .with_context(|| format!("Opening repo {} failed", repo_path.display()))?;
+
+    let status = super::working_tree::status(repo_path, app.clone()).with_context(|| {
+        format!(
+            "Determining status of work tree {} failed",
+            repo_path.display()
+        )
+    })?;
+
+    // Check that there is anything to snapshot.
+    if status.is_empty() {
+        return Ok(None);
+    }
+
+    let sandbox = app.sandbox();
+    // There are changes, let's get started...
+    // Create a diff of tracked changes.
+    let (tracked_change_patch_file, tracked_change_patch_path, _serial) =
+        sandbox.create_file(Some("tracked-changes"), Some("patch"), None)?;
+    let (mut cmd, scmd) = git_helper::git_command(app.clone())?;
+    cmd.current_dir(repo_path.as_os_str())
+        .arg("diff")
+        .arg("HEAD")
+        .stdout(Stdio::from(tracked_change_patch_file));
+    scmd.ensure_success_or_log(
+        &mut cmd,
+        crate::sandbox_command::SandboxCommandOutput::Stderr,
+    )?;
+
+    // Create the archive file.
+    let head_commit =
+        git_helper::get_head_commit(&repo).context("Could not determine HEAD commit")?;
+    let file_stem = hex::encode(head_commit.id());
+    let (archive_file, archive_path, _serial) =
+        sandbox.create_file(Some(file_stem.as_str()), Some("snapshot.tar"), None)?;
+
+    let mut archive_builder = Builder::new(BufWriter::new(archive_file));
+
+    // Add the index.
+    {
+        let index_path = git_dir.join("index");
+        let index_lock_path = index_path.with_extension("lock");
+        let _index_lock = LockFile::new(&index_lock_path).context("Locking the index failed")?;
+        archive_builder
+            .append_path_with_name(&index_path, ".git/index")
+            .with_context(|| format!("Adding index from {}", index_path.display()))?;
+    }
+
+    // Add the patch of tracked changes.
+    archive_builder
+        .append_path_with_name(
+            tracked_change_patch_path.as_path(),
+            Path::new(".git").join(TRACKED_CHANGE_PATCH_FILENAME.as_path()),
+        )
+        .with_context(|| format!("Adding patch from {}", tracked_change_patch_path.display()))?;
+
+    // Add untracked files.
+    for entry in status
+        .find_entries_with_disposition(Disposition::Untracked)
+        .context("Failed to find untracked entries")?
+    {
+        let path = repo_path.join(&entry.path);
+
+        archive_builder
+            .append_path_with_name(&path, &entry.path)
+            .with_context(|| format!("Failed to add file {}", path.display()))?;
+    }
+
+    // Clean up the working tree by cleaning untracked files.
+    let _ = git_helper::run_consuming_stdout(repo_path, vec!["clean", "-f", "-d"], app.clone())?;
+    let _ = git_helper::run_consuming_stdout(repo_path, vec!["reset", "--hard"], app.clone())?;
+
+    Ok(Some(CreationResult { path: archive_path }))
+}
+
+pub fn apply(
+    snapshot_path: impl AsRef<Path>,
+    repo_path: impl AsRef<Path>,
+    app: Arc<App>,
+) -> Result<()> {
+    let repo_path = repo_path.as_ref();
+    let git_dir = git_helper::git_dir(repo_path)?;
+
+    let status = super::working_tree::status(repo_path, app.clone()).with_context(|| {
+        format!(
+            "Determining status of work tree {} failed",
+            repo_path.display()
+        )
+    })?;
+
+    // Check that there is anything to snapshot.
+    if !status.is_empty() {
+        bail!("The working tree must be clean in order to restore a snapshot");
+    }
+
+    let snapshot_path = snapshot_path.as_ref();
+    let mut snapshot_archive = Archive::new(BufReader::new(
+        File::open(snapshot_path).with_context(|| {
+            format!(
+                "Failed to open snapshot archive {}",
+                snapshot_path.display()
+            )
+        })?,
+    ));
+
+    snapshot_archive.set_overwrite(true);
+    snapshot_archive.set_preserve_permissions(true);
+    snapshot_archive.set_preserve_mtime(true);
+    snapshot_archive.set_unpack_xattrs(true);
+
+    snapshot_archive.unpack(repo_path).with_context(|| {
+        format!(
+            "Failed to unpack snapshot archive {}",
+            snapshot_path.display()
+        )
+    })?;
+
+    // Apply the patch
+    let patch_path = git_dir.join(TRACKED_CHANGE_PATCH_FILENAME.as_path());
+    let patch_path_str = patch_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Failed to convert patch path to a string"))?;
+
+    let _ = git_helper::run_consuming_stdout(
+        repo_path,
+        vec!["apply", "-v", patch_path_str],
+        app.clone(),
+    )?;
+
+    // Remove the patch file
+    std::fs::remove_file(&patch_path)
+        .with_context(|| format!("Failed to remove patch file {}", patch_path.display()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod testing {
+    use anyhow::Result;
+    use focus_testing::{init_logging, ScratchGitRepo};
+
+    use crate::git;
+
+    use super::*;
+
+    #[test]
+    fn snapshot_smoke_test() -> Result<()> {
+        init_logging();
+
+        let app = Arc::new(App::new_for_testing()?);
+        let repo_dir = app.sandbox().create_subdirectory("repo")?;
+
+        let repo = ScratchGitRepo::new_static_fixture(&repo_dir)?;
+
+        let tracked_removed_filename = PathBuf::from("a-tracked-file-added-and-later-deleted.txt");
+        let tracked_removed_path = repo.path().join(&tracked_removed_filename);
+        let tracked_removed_content = b"This file is added and later deleted.\n";
+        std::fs::write(&tracked_removed_path, tracked_removed_content)?;
+        repo.add_file(&tracked_removed_filename)?;
+        repo.write_and_commit_file(
+            &tracked_removed_filename,
+            tracked_removed_content,
+            format!("Commit of {}", tracked_removed_filename.display()),
+        )?;
+        repo.remove_file(&tracked_removed_filename)?;
+
+        let tracked_filename = PathBuf::from("a-tracked-file.txt");
+        let tracked_file_path = repo.path().join(&tracked_filename);
+        let tracked_file_content = b"This file is added.\n";
+        std::fs::write(&tracked_file_path, tracked_file_content)?;
+        repo.add_file(&tracked_filename)?;
+
+        let untracked_file_name = PathBuf::from("an-untracked-file.txt");
+        let untracked_file_path = repo.path().join(&untracked_file_name);
+        let untracked_content = b"This file is untracked.\n";
+        std::fs::write(&untracked_file_path, untracked_content)?;
+
+        // Check that the status is what we expect.
+        let initial_status = git::working_tree::status(repo.path(), app.clone())?;
+        {
+            let untracked_entries =
+                initial_status.find_entries_with_disposition(Disposition::Untracked)?;
+            let untracked_entry = untracked_entries
+                .iter()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
+            assert_eq!(untracked_entry.path.as_path(), &untracked_file_name);
+
+            let tracked_entries =
+                initial_status.find_entries_with_disposition(Disposition::Added)?;
+            {
+                let tracked_entry = tracked_entries.iter().next().ok_or_else(|| {
+                    anyhow::anyhow!("Expected an untracked entry and there was none")
+                })?;
+                assert_eq!(tracked_entry.path.as_path(), &tracked_filename);
+            }
+        }
+
+        let snapshot = git::snapshot::create(repo.path(), app.clone())
+            .context("Creating the snapshot failed")?
+            .ok_or_else(|| anyhow::anyhow!("Expected a snapshot to be created"))?;
+        let snapshot_stat =
+            std::fs::metadata(&snapshot.path).context("Could not stat snapshot file")?;
+        assert!(snapshot_stat.is_file());
+        assert!(snapshot_stat.len() > 0);
+
+        // After the snapshot is created, the tree should be in a clean state.
+        {
+            let status = git::working_tree::status(repo.path(), app.clone())?;
+            tracing::debug!(entries = ?status.entries());
+            assert!(status.is_empty());
+        }
+
+        // Apply the snapshot, check that everything is as before.
+        {
+            assert!(tracked_removed_path.is_file());
+
+            git::snapshot::apply(&snapshot.path, repo.path(), app.clone())
+                .context("Applying snapshot failed")?;
+
+            // The patch should have removed the file.
+            assert!(!tracked_removed_path.is_file());
+
+            // The working tree status should be the same.
+            let status = git::working_tree::status(repo.path(), app.clone())?;
+            assert_eq!(status, initial_status);
+        }
+
+        Ok(())
+    }
+}

--- a/focus/util/src/git/snapshot.rs
+++ b/focus/util/src/git/snapshot.rs
@@ -25,9 +25,15 @@ use crate::{app::App, git_helper, lock_file::LockFile};
 use super::model::Disposition;
 
 pub struct CreationResult {
+pub struct SnapshotResult {
     pub path: PathBuf,
 }
 
+impl SnapshotResult {
+    pub fn path(&self) -> &Path {
+        &self.path.as_path()
+    }
+}
 lazy_static! {
     static ref TRACKED_CHANGE_PATCH_FILENAME: PathBuf = PathBuf::from("tracked-changes.patch");
 }
@@ -41,7 +47,7 @@ lazy_static! {
 /// a/changed/path                 # Untracked changed files ...
 ///
 /// The archive should preserve ownership, modes, and extended attributes on the files.
-pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<CreationResult>> {
+pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<SnapshotResult>> {
     let repo_path = repo_path.as_ref();
     let git_dir = git_helper::git_dir(repo_path)?;
     let repo = Repository::open(repo_path)
@@ -117,7 +123,7 @@ pub fn create(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<Option<Creat
     let _ = git_helper::run_consuming_stdout(repo_path, vec!["clean", "-f", "-d"], app.clone())?;
     let _ = git_helper::run_consuming_stdout(repo_path, vec!["reset", "--hard"], app)?;
 
-    Ok(Some(CreationResult { path: archive_path }))
+    Ok(Some(SnapshotResult { path: archive_path }))
 }
 
 pub fn apply(

--- a/focus/util/src/git/working_tree.rs
+++ b/focus/util/src/git/working_tree.rs
@@ -239,9 +239,7 @@ mod testing {
         {
             let status = git::working_tree::status(repo.path(), app.clone())?;
             let entries = status.find_entries_with_disposition(Disposition::Untracked)?;
-            let entry = entries
-                .iter()
-                .next()
+            let entry = entries.first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(entry.path.as_path(), &file_name);
         }
@@ -252,9 +250,7 @@ mod testing {
         {
             let status = git::working_tree::status(repo.path(), app.clone())?;
             let entries = status.find_entries_with_disposition(Disposition::Added)?;
-            let entry = entries
-                .iter()
-                .next()
+            let entry = entries.first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(entry.path.as_path(), &file_name);
         }
@@ -263,7 +259,7 @@ mod testing {
 
         // After we commit everything there are no changes to report
         {
-            let status = git::working_tree::status(repo.path(), app.clone())?;
+            let status = git::working_tree::status(repo.path(), app)?;
             assert!(status.is_empty());
         }
 

--- a/focus/util/src/git/working_tree.rs
+++ b/focus/util/src/git/working_tree.rs
@@ -1,0 +1,273 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+    vec,
+};
+
+use crate::{app::App, git_helper};
+
+use super::model::{Disposition, Kind};
+
+/// Each entity represents a changed path in the working tree. Trees in the merge state are not supported.
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct WorkingTreeStateEntry {
+    pub kind: Kind,
+    pub x: Disposition,
+    pub y: Option<Disposition>,
+
+    pub path: PathBuf,
+    pub original_path: Option<PathBuf>,
+}
+
+impl WorkingTreeStateEntry {
+    // If there is a deleted path returns it.
+    pub fn deleted_path(&self) -> Result<Option<PathBuf>> {
+        match self.kind {
+            Kind::Ordinary => {
+                // If any char is 'D' there was a deletion
+                if self.x == Disposition::Deleted || self.y == Some(Disposition::Deleted) {
+                    Ok(Some(self.path.clone()))
+                } else {
+                    Ok(None)
+                }
+            }
+            Kind::RenameOrCopy => {
+                // Original path is removed. */
+                Ok(Some(self.original_path.clone().ok_or_else(|| {
+                    anyhow::anyhow!("Missing original path for rename/copy")
+                })?))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn dispositions(&self) -> Vec<Disposition> {
+        let mut dispositions = Vec::<Disposition>::new();
+        dispositions.push(self.x);
+        if let Some(y) = self.y {
+            dispositions.push(y);
+        }
+        dispositions
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct WorkingTreeState {
+    /// Entities organized by
+    entries: Vec<WorkingTreeStateEntry>,
+
+    /// Index of entity disposition to index in entities.
+    by_disposition: HashMap<Disposition, Vec<usize>>,
+}
+
+impl WorkingTreeState {
+    fn new() -> Self {
+        let mut instance: WorkingTreeState = Default::default();
+        for d in vec![
+            Disposition::Unmodified,
+            Disposition::Modified,
+            Disposition::FileTypeChanged,
+            Disposition::Added,
+            Disposition::Deleted,
+            Disposition::Renamed,
+            Disposition::Copied,
+            Disposition::UpdatedButUnmerged,
+            Disposition::Untracked,
+            Disposition::Ignored,
+        ] {
+            instance.by_disposition.insert(d, Vec::new());
+        }
+        instance
+    }
+
+    fn push(&mut self, entry: WorkingTreeStateEntry) -> Result<()> {
+        let index = self.entries.len();
+
+        // Add all dispositions to the index.
+        for disposition in entry.dispositions() {
+            let indices = self
+                .by_disposition
+                .get_mut(&disposition)
+                .ok_or_else(|| anyhow::anyhow!("Missing disposition {:?}", disposition))?;
+            indices.push(index);
+        }
+
+        self.entries.push(entry);
+
+        Ok(())
+    }
+
+    /// Get a reference to the underlying entries.
+    pub fn entries(&self) -> &Vec<WorkingTreeStateEntry> {
+        &self.entries
+    }
+
+    /// Find entries with the given disposition
+    pub fn find_entries_with_disposition(
+        &self,
+        disposition: Disposition,
+    ) -> Result<Vec<&WorkingTreeStateEntry>> {
+        let indices = self
+            .by_disposition
+            .get(&disposition)
+            .ok_or_else(|| anyhow::anyhow!("Missing disposition {:?}", disposition))?;
+        Ok(indices.iter().map(|i| &self.entries[*i]).collect())
+    }
+
+    /// Returns true if there are no changes to the working tree.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Determine the line type from the initial token
+fn determine_kind(token: &str) -> Option<Kind> {
+    match token {
+        s if s.eq("#") => Some(Kind::Header),
+        s if s.eq("1") => Some(Kind::Ordinary),
+        s if s.eq("2") => Some(Kind::RenameOrCopy),
+        s if s.eq("u") => Some(Kind::Unmerged),
+        s if s.eq("?") => Some(Kind::Untracked),
+        s if s.eq("!") => Some(Kind::Untracked),
+        _ => None,
+    }
+}
+
+/// Parse a working tree status from the porcelain v2 format into a vector.
+pub fn status(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<WorkingTreeState> {
+    let mut state = WorkingTreeState::new();
+    let output = git_helper::run_consuming_stdout(
+        repo_path,
+        &["status", "--porcelain=2", "-z", "--ignore-submodules=all"],
+        app,
+    )?;
+
+    let mut null_delimited_split = output.split('\0');
+    while let Some(frame) = null_delimited_split.next() {
+        let tokens = frame.split_ascii_whitespace().collect::<Vec<&str>>();
+        if tokens.is_empty() {
+            break;
+        }
+        tracing::debug!(?tokens);
+        if tokens.len() < 2 {
+            bail!("Too few tokens in `{:?}`", tokens);
+        }
+
+        let mut token_iter = tokens.iter();
+        let kind_token = token_iter
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Expected kind token (index 0)"))?;
+        let kind = determine_kind(kind_token)
+            .ok_or_else(|| anyhow::anyhow!("Unexpected initial token '{}'", kind_token))?;
+        let path = tokens
+            .last()
+            .ok_or_else(|| anyhow::anyhow!("Missing path token"))?;
+
+        // If the entry is a rename or copy it will have another frame with just the original path
+        let original_path = if kind == Kind::RenameOrCopy {
+            let frame = null_delimited_split.next().ok_or_else(|| {
+                anyhow::anyhow!("Expected another frame containing the original path")
+            })?;
+            Some(PathBuf::from(frame))
+        } else {
+            None
+        };
+
+        // TODO: Expand the implementation here to parse all of the fields for each variant rather than taking only what we need.
+        let flag_chars: Vec<char> = {
+            // For untracked and ignored entries there is no initial numerical token, the first token is disposition
+            let flags = match kind {
+                Kind::Untracked => kind_token,
+                Kind::Ignored => kind_token,
+                _ => token_iter
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("Expected flag token (index 1)"))?,
+            };
+            flags.chars().collect()
+        };
+        if flag_chars.len() < 1 {
+            bail!("Disposition flags too short");
+        }
+
+        let x = Disposition::try_from(flag_chars[0])?;
+        let y = if flag_chars.len() > 1 {
+            Some(Disposition::try_from(flag_chars[1])?)
+        } else {
+            None
+        };
+
+        state.push(WorkingTreeStateEntry {
+            kind,
+            x,
+            y,
+            path: PathBuf::from(path),
+            original_path,
+        })?;
+    }
+
+    Ok(state)
+}
+
+#[cfg(test)]
+mod testing {
+    use anyhow::Result;
+    use focus_testing::{init_logging, ScratchGitRepo};
+    use tempfile::tempdir;
+
+    use crate::git;
+
+    use super::*;
+
+    #[test]
+    fn status_smoke_test() -> Result<()> {
+        init_logging();
+
+        let app = Arc::new(App::new_for_testing()?);
+        let dir = tempdir().unwrap();
+        let repo = ScratchGitRepo::new_static_fixture(dir.path())?;
+
+        let file_name = PathBuf::from("file-1.txt");
+        let untracked_file_path = repo.path().join(&file_name);
+        std::fs::write(&untracked_file_path, b"Hello!\n")?;
+
+        // Write a new file and check that its disposition is untracked
+        {
+            let status = git::working_tree::status(repo.path(), app.clone())?;
+            let entries = status.find_entries_with_disposition(Disposition::Untracked)?;
+            let entry = entries
+                .iter()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
+            assert_eq!(entry.path.as_path(), &file_name);
+        }
+
+        repo.add_file(&file_name)?;
+
+        // After the file is added check that its disposition is staged
+        {
+            let status = git::working_tree::status(repo.path(), app.clone())?;
+            let entries = status.find_entries_with_disposition(Disposition::Added)?;
+            let entry = entries
+                .iter()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
+            assert_eq!(entry.path.as_path(), &file_name);
+        }
+
+        repo.commit_all("Add a file")?;
+
+        // After we commit everything there are no changes to report
+        {
+            let status = git::working_tree::status(repo.path(), app.clone())?;
+            assert!(status.is_empty());
+        }
+
+        Ok(())
+    }
+}

--- a/focus/util/src/git/working_tree.rs
+++ b/focus/util/src/git/working_tree.rs
@@ -239,7 +239,8 @@ mod testing {
         {
             let status = git::working_tree::status(repo.path(), app.clone())?;
             let entries = status.find_entries_with_disposition(Disposition::Untracked)?;
-            let entry = entries.first()
+            let entry = entries
+                .first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(entry.path.as_path(), &file_name);
         }
@@ -250,7 +251,8 @@ mod testing {
         {
             let status = git::working_tree::status(repo.path(), app.clone())?;
             let entries = status.find_entries_with_disposition(Disposition::Added)?;
-            let entry = entries.first()
+            let entry = entries
+                .first()
                 .ok_or_else(|| anyhow::anyhow!("Expected an untracked entry and there was none"))?;
             assert_eq!(entry.path.as_path(), &file_name);
         }
@@ -259,9 +261,11 @@ mod testing {
 
         // After we commit everything there are no changes to report
         {
-            let status = git::working_tree::status(repo.path(), app)?;
+            let status = git::working_tree::status(repo.path(), app.clone())?;
             assert!(status.is_empty());
         }
+
+        drop(app);
 
         Ok(())
     }

--- a/focus/util/src/git/working_tree.rs
+++ b/focus/util/src/git/working_tree.rs
@@ -47,8 +47,7 @@ impl WorkingTreeStateEntry {
     }
 
     fn dispositions(&self) -> Vec<Disposition> {
-        let mut dispositions = Vec::<Disposition>::new();
-        dispositions.push(self.x);
+        let mut dispositions = vec![self.x];
         if let Some(y) = self.y {
             dispositions.push(y);
         }

--- a/focus/util/src/git/working_tree.rs
+++ b/focus/util/src/git/working_tree.rs
@@ -7,7 +7,6 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
-    vec,
 };
 
 use crate::{app::App, git_helper};
@@ -69,7 +68,7 @@ pub struct WorkingTreeState {
 impl WorkingTreeState {
     fn new() -> Self {
         let mut instance: WorkingTreeState = Default::default();
-        for d in vec![
+        for d in &[
             Disposition::Unmodified,
             Disposition::Modified,
             Disposition::FileTypeChanged,
@@ -81,7 +80,7 @@ impl WorkingTreeState {
             Disposition::Untracked,
             Disposition::Ignored,
         ] {
-            instance.by_disposition.insert(d, Vec::new());
+            instance.by_disposition.insert(*d, Vec::new());
         }
         instance
     }
@@ -144,7 +143,7 @@ pub fn status(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<WorkingTreeS
     let mut state = WorkingTreeState::new();
     let output = git_helper::run_consuming_stdout(
         repo_path,
-        &["status", "--porcelain=2", "-z", "--ignore-submodules=all"],
+        ["status", "--porcelain=2", "-z", "--ignore-submodules=all"],
         app,
     )?;
 
@@ -191,8 +190,8 @@ pub fn status(repo_path: impl AsRef<Path>, app: Arc<App>) -> Result<WorkingTreeS
             };
             flags.chars().collect()
         };
-        if flag_chars.len() < 1 {
-            bail!("Disposition flags too short");
+        if flag_chars.is_empty() {
+            bail!("Disposition flags empty");
         }
 
         let x = Disposition::try_from(flag_chars[0])?;

--- a/focus/util/src/git_helper.rs
+++ b/focus/util/src/git_helper.rs
@@ -177,7 +177,7 @@ pub fn read_config<P: AsRef<Path>>(
     key: &str,
     app: Arc<App>,
 ) -> Result<Option<String>> {
-    if let Ok(result) = run_consuming_stdout(repo_path, &["config", key], app) {
+    if let Ok(result) = run_consuming_stdout(repo_path, ["config", key], app) {
         return Ok(Some(result));
     }
 
@@ -215,7 +215,7 @@ pub fn find_top_level(app: Arc<App>, path: impl AsRef<Path>) -> Result<PathBuf> 
     let path = path.as_ref();
     if let Ok(path) = std::fs::canonicalize(path) {
         Ok(PathBuf::from(
-            run_consuming_stdout(path, &["rev-parse", "--show-toplevel"], app)
+            run_consuming_stdout(path, ["rev-parse", "--show-toplevel"], app)
                 .context("Finding the repo's top level failed")?,
         ))
     } else {
@@ -227,15 +227,15 @@ pub fn find_top_level(app: Arc<App>, path: impl AsRef<Path>) -> Result<PathBuf> 
 }
 
 pub fn get_current_revision(app: Arc<App>, repo: &Path) -> Result<String> {
-    run_consuming_stdout(repo, &["rev-parse", "HEAD"], app)
+    run_consuming_stdout(repo, ["rev-parse", "HEAD"], app)
 }
 
 pub fn get_current_branch(app: Arc<App>, repo: &Path) -> Result<String> {
-    run_consuming_stdout(repo, &["branch", "--show-current"], app)
+    run_consuming_stdout(repo, ["branch", "--show-current"], app)
 }
 
 pub fn parse_ref(app: Arc<App>, repo: &Path, reference: &str) -> Result<String> {
-    run_consuming_stdout(repo, &["rev-parse", "--revs-only", reference], app)
+    run_consuming_stdout(repo, ["rev-parse", "--revs-only", reference], app)
 }
 
 pub fn get_merge_base(
@@ -326,7 +326,7 @@ impl BranchSwitch {
         if detach {
             cmd.arg("--detach");
         }
-        cmd.arg(&branch_name);
+        cmd.arg(branch_name);
 
         if let Some(alternate_path) = &self.alternate {
             cmd.env(

--- a/focus/util/src/git_helper.rs
+++ b/focus/util/src/git_helper.rs
@@ -29,8 +29,14 @@ use super::time::{FocusTime, GitTime};
 
 pub use focus_testing::GitBinary;
 
-pub fn git_dir(path: &Path) -> Result<PathBuf> {
-    Ok(git2::Repository::open(path)?.path().to_path_buf())
+pub fn git_dir(path: &Path, app: Arc<App>) -> Result<PathBuf> {
+    let found_path = run_consuming_stdout(path, vec!["rev-parse", "--git-dir"], app)?;
+    let found_path = PathBuf::from(&found_path);
+    if found_path.is_absolute() {
+        Ok(found_path)
+    } else {
+        Ok(path.join(found_path.as_path()))
+    }
 }
 
 pub fn git_command_with_git_binary(

--- a/focus/util/src/git_helper.rs
+++ b/focus/util/src/git_helper.rs
@@ -20,6 +20,7 @@ use tracing::{error, warn};
 
 use crate::{
     app::App,
+    process,
     sandbox_command::{SandboxCommand, SandboxCommandOutput},
     time::GitIdentTime,
 };
@@ -203,8 +204,9 @@ where
 {
     let (mut cmd, scmd) = git_command(app)?;
     if let Err(e) = cmd.current_dir(repo).args(args).status() {
-        scmd.log(SandboxCommandOutput::Stderr, "git command")?;
-        bail!("git command failed: {}", e);
+        let cmd_description = process::pretty_print_command(&mut cmd);
+        scmd.log(SandboxCommandOutput::Stderr, cmd_description.as_str())?;
+        bail!("Git command '{}' failed: {}", cmd_description, e);
     }
     let mut stdout_contents = String::new();
     scmd.read_to_string(SandboxCommandOutput::Stdout, &mut stdout_contents)?;

--- a/focus/util/src/lib.rs
+++ b/focus/util/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod backed_up_file;
+pub mod files;
 pub mod git;
 pub mod git_helper;
 pub mod lock_file;

--- a/focus/util/src/lib.rs
+++ b/focus/util/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod backed_up_file;
+pub mod git;
 pub mod git_helper;
 pub mod lock_file;
 pub mod paths;

--- a/focus/util/src/paths.rs
+++ b/focus/util/src/paths.rs
@@ -144,19 +144,19 @@ mod tests {
 
     #[test]
     fn test_is_relevant_to_build_graph() {
-        assert!(is_relevant_to_build_graph(&Path::new("WORKSPACE.weird")));
-        assert!(is_relevant_to_build_graph(&Path::new("WORKSPACE")));
-        assert!(is_relevant_to_build_graph(&Path::new("BUILD.weird")));
-        assert!(is_relevant_to_build_graph(&Path::new("BUILD")));
-        assert!(is_relevant_to_build_graph(&Path::new("jank.bzl")));
-        assert!(!is_relevant_to_build_graph(&Path::new("foo.c")));
+        assert!(is_relevant_to_build_graph(Path::new("WORKSPACE.weird")));
+        assert!(is_relevant_to_build_graph(Path::new("WORKSPACE")));
+        assert!(is_relevant_to_build_graph(Path::new("BUILD.weird")));
+        assert!(is_relevant_to_build_graph(Path::new("BUILD")));
+        assert!(is_relevant_to_build_graph(Path::new("jank.bzl")));
+        assert!(!is_relevant_to_build_graph(Path::new("foo.c")));
     }
 
     #[test]
     fn test_is_involved_in_build() {
-        assert!(is_build_definition(&Path::new("BUILD.funky")));
-        assert!(is_build_definition(&Path::new("BUILD")));
-        assert!(!is_build_definition(&Path::new("bar.c")));
+        assert!(is_build_definition(Path::new("BUILD.funky")));
+        assert!(is_build_definition(Path::new("BUILD")));
+        assert!(!is_build_definition(Path::new("bar.c")));
     }
 
     #[test]

--- a/focus/util/src/process.rs
+++ b/focus/util/src/process.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Twitter, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{ffi::OsStr, path::PathBuf, process::Command};
 
 /// Returns a textual description of the current process
 pub fn get_process_description() -> String {
@@ -23,4 +23,16 @@ pub fn get_process_description() -> String {
         whoami::username(),
         whoami::hostname()
     )
+}
+
+pub fn pretty_print_command<'cmd>(command: &'cmd mut Command) -> String {
+    let convert_os_str =
+        |s: &'cmd OsStr| -> &'cmd str { s.to_str().unwrap_or("<???>").trim_matches('"') };
+
+    let mut buf = convert_os_str(command.get_program()).to_owned();
+    for arg in command.get_args() {
+        buf.push(' ');
+        buf.push_str(convert_os_str(arg));
+    }
+    buf
 }

--- a/focus/util/src/sandbox/cleanup.rs
+++ b/focus/util/src/sandbox/cleanup.rs
@@ -304,7 +304,7 @@ cleanup = 72
 
                 let new_time: FileTime = (ft - chrono::Duration::hours(i as i64)).into();
 
-                filetime::set_file_mtime(&p, new_time)?;
+                filetime::set_file_mtime(p, new_time)?;
             }
 
             paths.sort_unstable_by_key(|p| p.metadata().unwrap().modified().unwrap());

--- a/focus/util/src/sandbox/mod.rs
+++ b/focus/util/src/sandbox/mod.rs
@@ -208,7 +208,7 @@ mod tests {
             .file_name()
             .unwrap()
             .to_string_lossy()
-            .starts_with(&DEFAULT_NAME_PREFIX));
+            .starts_with(DEFAULT_NAME_PREFIX));
 
         let named_sandbox = Sandbox::new(false, Some("test_"))?;
         assert!(named_sandbox
@@ -216,7 +216,7 @@ mod tests {
             .file_name()
             .unwrap()
             .to_string_lossy()
-            .starts_with(&DEFAULT_NAME_PREFIX));
+            .starts_with(DEFAULT_NAME_PREFIX));
 
         Ok(())
     }

--- a/focus/util/src/sandbox/mod.rs
+++ b/focus/util/src/sandbox/mod.rs
@@ -105,6 +105,8 @@ impl Sandbox {
         }
     }
 
+    // TODO: Refactor naming temporary files into a separate function so that we don't have to waste time opening later...
+
     pub fn create_file(
         &self,
         prefix: Option<&str>,

--- a/focus/util/src/sandbox/mod.rs
+++ b/focus/util/src/sandbox/mod.rs
@@ -123,7 +123,7 @@ impl Sandbox {
             path.set_extension(extension);
         }
         let qualified_path = parent.join(path);
-        let file = File::create(&qualified_path.as_path()).context("creating a temporary file")?;
+        let file = File::create(qualified_path.as_path()).context("creating a temporary file")?;
 
         Ok((file, qualified_path, serial))
     }

--- a/focus/util/src/sandbox_command.rs
+++ b/focus/util/src/sandbox_command.rs
@@ -102,11 +102,11 @@ impl SandboxCommand {
         let stdin = stdin.unwrap_or_else(Stdio::null);
 
         let (stdout, stdout_path) = match stdout {
-            Some(path) => (Stdio::from(File::open(&path)?), path.to_owned()),
+            Some(path) => (Stdio::from(File::open(path)?), path.to_owned()),
             None => output_file("stdout").context("Failed preparing stdout")?,
         };
         let (stderr, stderr_path) = match stderr {
-            Some(path) => (Stdio::from(File::open(&path)?), path.to_owned()),
+            Some(path) => (Stdio::from(File::open(path)?), path.to_owned()),
             None => output_file("stderr").context("Failed preparing stderr")?,
         };
 


### PR DESCRIPTION
**git::working_tree::status** parses output from git-status with porcelain v2 into easy-to-use models

**git::working_tree::snapshot** creates and restores snapshots of working tree state using tarballs to store untracked files, a patch against `HEAD`, and the index